### PR TITLE
Change test assembly name to "Com.Unity.Toonshader.Editor.Tests"

### DIFF
--- a/com.unity.toonshader/Tests/Editor/Com.Unity.ToonShader.Tests.Editor.asmdef
+++ b/com.unity.toonshader/Tests/Editor/Com.Unity.ToonShader.Tests.Editor.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "Tests",
+    "name": "Com.Unity.Toonshader.Editor.Tests",
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner"


### PR DESCRIPTION
I ran into a case where another package had the same name as the tests asmdef, which was just "Tests."

I believe changing the assembly name to "Com.Unity.Toonshader.Editor.Tests" (named after the existing "Com.Unity.Toonshader.Editor" asmdef, and similar naming pattern to some standard packages like [ProBuilder](https://github.com/Unity-Technologies/com.unity.probuilder/blob/master/Tests/Editor/Unity.ProBuilder.Editor.Tests.asmdef)) would be good.