### PR TITLE
Feature/legacy outline flicker

### DIFF
--- a/com.unity.toonshader/CHANGELOG.md
+++ b/com.unity.toonshader/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 ## [0.3.0-preview] - 2021-09-27
 * HDRP: Fixed wiered steps when more than 3 point lights are in a scene.
-* Added Toon EV Adjustement per Model.
+* HDRP: Added Toon EV Adjustement per Model.
+* HDRP: Compatible with Raytrace Hardshadow when DX12 is chosen as API.
+* Legacy: Applied a fix for outline flicker in VR chat..
 ## [0.2.2-preview] - 2021-08-24
 * Modefind Toon EV Adjustment Curve inspector.
 * Exclued unnecessary files from release zip.

--- a/com.unity.toonshader/Runtime/Legacy/Shaders/LegacyToon.shader
+++ b/com.unity.toonshader/Runtime/Legacy/Shaders/LegacyToon.shader
@@ -210,7 +210,7 @@ Shader "Toon (Built-in)" {
         Pass {
             Name "Outline"
             Tags {
-                "LightMode" = "Always"
+                "LightMode"="ForwardBase"
             }
             Cull[_SRPDefaultUnlitColMode]
             ColorMask[_SPRDefaultUnlitColorMask]

--- a/com.unity.toonshader/Runtime/Legacy/Shaders/LegacyToonTessellation.shader
+++ b/com.unity.toonshader/Runtime/Legacy/Shaders/LegacyToonTessellation.shader
@@ -211,7 +211,7 @@ Shader "ToonTessellation (Built-in)" {
         Pass {
             Name "Outline"
             Tags {
-                "LightMode" = "Always"
+                "LightMode"="ForwardBase"
             }
             Cull[_SRPDefaultUnlitColMode]
             ColorMask[_SPRDefaultUnlitColorMask]


### PR DESCRIPTION
Backported legacy outline flicker fix from Unitychan Toon Shader 2.0.8