### PR TITLE
Fixed UniversalToonOutline not rendering to right eye

### DIFF
--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonOutline.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonOutline.hlsl
@@ -10,6 +10,8 @@
                 float3 normal : NORMAL;
                 float4 tangent : TANGENT;
                 float2 texcoord0 : TEXCOORD0;
+
+                UNITY_VERTEX_INPUT_INSTANCE_ID
             };
             struct VertexOutput {
                 float4 pos : SV_POSITION;
@@ -17,9 +19,15 @@
                 float3 normalDir : TEXCOORD1;
                 float3 tangentDir : TEXCOORD2;
                 float3 bitangentDir : TEXCOORD3;
+
+                UNITY_VERTEX_OUTPUT_STEREO
             };
             VertexOutput vert (VertexInput v) {
                 VertexOutput o = (VertexOutput)0;
+
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
                 o.uv0 = v.texcoord0;
                 float4 objPos = mul ( unity_ObjectToWorld, float4(0,0,0,1) );
                 float2 Set_UV0 = o.uv0;


### PR DESCRIPTION
In its current state, UTS3 (URP) does not render the outline to the right eye in VR applications. Using the guidelines in https://docs.unity3d.com/2021.2/Documentation/Manual/SinglePassInstancing.html, I've adapted the UniversalToonOutline pass to render to the right eye as well.

Before:
![image](https://user-images.githubusercontent.com/4165560/135842648-e35950bd-09f0-4c28-be5b-cbaf79652eb0.png)

After:
![image](https://user-images.githubusercontent.com/4165560/135842850-c847ee85-6727-4662-b243-9167755d892d.png)

I am unsure about whether this problem exists in the HDRP / Legacy outline shaders.