### PR TITLE
Declared _SpecColor for compatibility with SRP Batcher

### DIFF
--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToon.shader
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToon.shader
@@ -21,12 +21,13 @@ Shader "Universal Render Pipeline/Toon" {
         _StencilOpFail("Stencil Operation", Float) = 0
         [Enum(OFF,0,ON,1)] _TransparentEnabled("Transparent Mode", int) = 0
 
-        // These two are used in Lit shader.
+        // These three are used in Lit shader.
         // inoorder to make the shaders compatible with SRP Batcher 
         // The following decralation is indespensable as they are used in CBUFFER UnityPerMaterial block.
         // 
         [HideInInspector] _Metallic("_Metallic", Range(0.0, 1.0)) = 0
         [HideInInspector] _Smoothness("Smoothness", Range(0.0, 1.0)) = 0.5
+        [HideInInspector] _SpecColor("_SpecColor", Color) = (1, 1, 1, 1)
 
 
         // DoubleShadeWithFeather


### PR DESCRIPTION
It looks like at some point, SRP Batcher compatibility was broken for the UTS3/URP shader. It looks like for an identical scene, SRP compatibility helps batch draw calls for shadows. The rest is unable to be batched because of UTS3/URP being multi-pass. 

I am wondering if there are any other ways to optimize this, since SRP batcher / dynamic batching / GPU instancing seem to not be options for UTS3/URP.

Before:
![image](https://user-images.githubusercontent.com/4165560/136252906-fa7b7a0b-3dcf-48cb-aa6d-65f70ecb165a.png)
![image](https://user-images.githubusercontent.com/4165560/136252931-9d58f5c3-c79e-4c3e-bc52-1167334b7267.png)

After:
![image](https://user-images.githubusercontent.com/4165560/136252950-b0a87d73-5fd6-4bdc-a4d8-928228974413.png)
![image](https://user-images.githubusercontent.com/4165560/136252965-949002fb-2e57-4b04-acb1-ddcdfb6bdbb3.png)
