### PR TITLE
fixed: URP: on later than 11, UTS materials don't recive shadows.

### DIFF
--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBody.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBody.hlsl
@@ -174,30 +174,31 @@
                 float3   direction;
                 float3   color;
                 float    distanceAttenuation;
-                real    shadowAttenuation;
-                int     type;
+                float    shadowAttenuation;
+                int      type;
             };
 
             ///////////////////////////////////////////////////////////////////////////////
             //                      Light Abstraction                                    //
             /////////////////////////////////////////////////////////////////////////////
-            real MainLightRealtimeShadowUTS(float4 shadowCoord, float4 positionCS)
+            half MainLightRealtimeShadowUTS(float4 shadowCoord, float4 positionCS)
             {
 #if !defined(MAIN_LIGHT_CALCULATE_SHADOWS)
-                return 1.0h;
+                return 1.0;
 #endif
                 ShadowSamplingData shadowSamplingData = GetMainLightShadowSamplingData();
                 half4 shadowParams = GetMainLightShadowParams();
 #if defined(UTS_USE_RAYTRACING_SHADOW)
                 float w = (positionCS.w == 0) ? 0.00001 : positionCS.w;
-                float4 screenPos =  ComputeScreenPos(positionCS/ w);
+                float4 screenPos = ComputeScreenPos(positionCS / w);
                 return SAMPLE_TEXTURE2D(_RaytracedHardShadow, sampler_RaytracedHardShadow, screenPos);
-#endif 
-
+#elif defined(_MAIN_LIGHT_SHADOWS_SCREEN)
+                return SampleScreenSpaceShadowmap(shadowCoord);
+#endif
                 return SampleShadowmap(TEXTURE2D_ARGS(_MainLightShadowmapTexture, sampler_MainLightShadowmapTexture), shadowCoord, shadowSamplingData, shadowParams, false);
             }
 
-            real AdditionalLightRealtimeShadowUTS(int lightIndex, float3 positionWS, float4 positionCS)
+            half AdditionalLightRealtimeShadowUTS(int lightIndex, float3 positionWS, float4 positionCS)
             {
 #if  defined(UTS_USE_RAYTRACING_SHADOW)
                 float w = (positionCS.w == 0) ? 0.00001 : positionCS.w;

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
@@ -103,8 +103,8 @@
 //DoubleShadeWithFeather
 #endif
 
-                real shadowAttenuation = 1.0;
-# ifdef _MAIN_LIGHT_SHADOWS
+                float shadowAttenuation = 1.0;
+#if defined(_MAIN_LIGHT_SHADOWS) || defined(_MAIN_LIGHT_SHADOWS_CASCADE) || defined(_MAIN_LIGHT_SHADOWS_SCREEN)
                 shadowAttenuation = mainLight.shadowAttenuation;
 
 # endif

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
@@ -94,12 +94,10 @@
 #endif
 
 
-                real shadowAttenuation = 1.0;
+                float shadowAttenuation = 1.0;
 
-# ifdef _MAIN_LIGHT_SHADOWS
-
+#if defined(_MAIN_LIGHT_SHADOWS) || defined(_MAIN_LIGHT_SHADOWS_CASCADE) || defined(_MAIN_LIGHT_SHADOWS_SCREEN)
                 shadowAttenuation = mainLight.shadowAttenuation;
-
 # endif
 
 


### PR DESCRIPTION
Fixed: 
URP: UTS_Materials don't receive shadows with Unity 2021.1 and 2021.2.