### PR TITLE
Task/1287 legacy stereo rendering

### DIFF
--- a/com.unity.toonshader/CHANGELOG.md
+++ b/com.unity.toonshader/CHANGELOG.md
@@ -87,6 +87,7 @@
 * Unify the notation in the converter with Unity-Chan Toon Shader 2.
 * Fixed some popups in the inspector window not to use connected names without spaces. Each name is separated by a space.
 * `Rimlight Mask` on URP and HDRP version were not working well.
+* Single pass stereo rendering was not working with legacy(built-in) tessellation shaders.
 ## [0.6.1-preview] - 2022-02-24
 ### Fixed:
 * typo in inspector.

--- a/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_Tess.cginc
+++ b/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_Tess.cginc
@@ -36,6 +36,7 @@ struct InternalTessInterp_VertexInput
     float3 normal : NORMAL;
     float4 texcoord0 : TEXCOORD0;
     float4 texcoord1 : TEXCOORD1;
+    UNITY_VERTEX_INPUT_INSTANCE_ID //
 };
 
 InternalTessInterp_VertexInput tess_VertexInput(VertexInput v)
@@ -46,6 +47,7 @@ InternalTessInterp_VertexInput tess_VertexInput(VertexInput v)
     o.normal = v.normal;
     o.texcoord0 = v.texcoord0;
     o.texcoord1 = v.texcoord1;
+    UNITY_TRANSFER_INSTANCE_ID(v,o);
     return o;
 }
 
@@ -85,6 +87,7 @@ inline VertexInput _ds_VertexInput(UnityTessellationFactors tessFactors, const O
     v.vertex.xyz += v.normal.xyz * _TessExtrusionAmount;
     v.texcoord0 = vi[0].texcoord0*bary.x + vi[1].texcoord0*bary.y + vi[2].texcoord0*bary.z;
     v.texcoord1 = vi[0].texcoord1*bary.x + vi[1].texcoord1*bary.y + vi[2].texcoord1*bary.z;
+    UNITY_TRANSFER_INSTANCE_ID(vi[0], v);
     return v;
 }
 


### PR DESCRIPTION
Fixed:
* Single pass stereo rendering was not working with legacy(built-in) tessellation shaders.