### PR TITLE
Fixed: The converter sometimes misidentified materials with older tha…

### DIFF
--- a/com.unity.toonshader/CHANGELOG.md
+++ b/com.unity.toonshader/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
-## [0.8.2-preview] - 2022-09-07
+## [0.8.2-preview] - 2022-09-08
 ### Updated:
 * Updated some documents.
 
 ### Fixed:
-* Some warinings.
-* URP shader was not working for WebGL.
+* Deleted some warinings.
+* The converter sometimes misidentified materials older than 0.7.x in Built-in UTS3 as older materials in Unitychan Toon Shader Ver 2.0.7.
+* URP shader was not working for WebGL/GLES 3.0.
 
 
 ## [0.8.1-preview] - 2022-08-24

--- a/com.unity.toonshader/Editor/Converter/FromUTS2/BuiltInUTS2toIntegratedConverter.cs
+++ b/com.unity.toonshader/Editor/Converter/FromUTS2/BuiltInUTS2toIntegratedConverter.cs
@@ -287,7 +287,11 @@ namespace UnityEditor.Rendering.Toon
                 {
                     continue;       // Not Unity-chan Toon Shader Ver 2.
                 }
-
+                var targetLine1 = Array.Find<string>(lines, line => line.StartsWith("    - _isUnityToonshader"));
+                if (targetLine1 != null)
+                {
+                    continue;      // Not Unity-chan Toon Shader Ver 2.
+                }
                 var targetLine2 = Array.Find<string>(lines, line => line.StartsWith("    - _utsVersion"));
                 if (targetLine2 == null)
                 {


### PR DESCRIPTION
…n Built-in UTS3 0.7.x  as older materials in Unitychan Toon Shader Ver 2.0.7.