### PR TITLE
Made URP Shader compatible with Forward+ renderer.

### DIFF
--- a/com.unity.toonshader/Editor/UTS3GUI.cs
+++ b/com.unity.toonshader/Editor/UTS3GUI.cs
@@ -894,6 +894,11 @@ namespace UnityEditor.Rendering.Toon
             public static readonly ColorProperty outlineColorText = new ColorProperty(label: "Outline Color",
                 tooltip: "Specifies the color of outline.",
                 propName: "_Outline_Color", isHDR: false);
+
+            // CUSTOM
+            public static readonly FloatProperty faceSDFOffsetText = new FloatProperty(label: "Face SDF Offset",
+                tooltip: "",
+                propName: "_SDF_Offset", defaultValue: 0);
         }
         // --------------------------------
 
@@ -2383,12 +2388,10 @@ namespace UnityEditor.Rendering.Toon
                 m_MaterialEditor.RegisterPropertyChangeUndo(Styles.sdfSamplerText.text);
                 if (ret)
                 {
-                    // material.SetFloat(CustomShaderPropUse_SDF, 1);
                     material.EnableKeyword("_USE_SDF");
                 }
                 else
                 {
-                    // material.SetFloat(CustomShaderPropUse_SDF, 0);
                     material.DisableKeyword("_USE_SDF");
                 }
             }
@@ -2398,6 +2401,7 @@ namespace UnityEditor.Rendering.Toon
                 EditorGUI.indentLevel++;
                 m_MaterialEditor.TexturePropertySingleLine(Styles.sdfSamplerText, sdf_Tex);
                 m_MaterialEditor.TextureScaleOffsetProperty(sdf_Tex);
+                GUI_FloatProperty(material, Styles.faceSDFOffsetText);
                 EditorGUI.indentLevel--;
             }
             EditorGUI.EndDisabledGroup();

--- a/com.unity.toonshader/Effects.meta
+++ b/com.unity.toonshader/Effects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 30b2760e559871e498be7293f6384ee6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.toonshader/Effects/ScanDissolver.cs
+++ b/com.unity.toonshader/Effects/ScanDissolver.cs
@@ -1,0 +1,61 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UTSCustom
+{
+    public class ScanDissolver : MonoBehaviour
+    {
+        public Vector4 origin;
+        public Color color;
+        public float range = 1f;
+        public float scanDuration = 1f;
+        public List<Material> targets = new List<Material>();
+
+
+        // Start is called before the first frame update
+        void Start()
+        {
+            foreach (var target in targets)
+            {
+                target.SetColor("_ScanDisColor", color);
+                target.SetVector("_ScanDisOrigin", origin);
+                target.SetFloat("_ScanDisRange", 0f);
+            }
+        }
+
+        private void OnValidate()
+        {
+            foreach (var target in targets)
+            {
+                target.SetVector("_ScanDisOrigin", origin);
+                target.SetColor("_ScanDisColor", color);
+                target.SetFloat("_ScanDisRange", range);
+            }
+        }
+
+        // Update is called once per frame
+        void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.Space))
+            {
+                StartCoroutine(DoScan(scanDuration, Time.deltaTime));
+            }
+        }
+
+        IEnumerator DoScan(float duration, float dt)
+        {
+            float elapsed = 0f;
+            while (elapsed < duration)
+            {
+                float currentRange = elapsed * range / duration;
+                foreach (var target in targets)
+                {
+                    target.SetFloat("_ScanDisRange", currentRange);
+                }
+                yield return null;
+                elapsed += dt;
+            }
+        }
+    }
+}

--- a/com.unity.toonshader/Effects/ScanDissolver.cs.meta
+++ b/com.unity.toonshader/Effects/ScanDissolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0590a6b3114c1ac46a1dc07b0c9b67a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.toonshader/Effects/Shaders.meta
+++ b/com.unity.toonshader/Effects/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 595a3b100af87d746a60a0fe7f943205
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.toonshader/Effects/Shaders/ScanSimpleLit.shader
+++ b/com.unity.toonshader/Effects/Shaders/ScanSimpleLit.shader
@@ -1,0 +1,586 @@
+// Shader targeted for low end devices. Single Pass Forward Rendering.
+Shader "Custom/ScanSimpleLit"
+{
+    // Keep properties of StandardSpecular shader for upgrade reasons.
+    Properties
+    {
+        [MainTexture] _BaseMap("Base Map (RGB) Smoothness / Alpha (A)", 2D) = "white" {}
+        [MainColor]   _BaseColor("Base Color", Color) = (1, 1, 1, 1)
+
+        _Cutoff("Alpha Clipping", Range(0.0, 1.0)) = 0.5
+
+        _Smoothness("Smoothness", Range(0.0, 1.0)) = 0.5
+        _SpecColor("Specular Color", Color) = (0.5, 0.5, 0.5, 0.5)
+        _SpecGlossMap("Specular Map", 2D) = "white" {}
+        _SmoothnessSource("Smoothness Source", Float) = 0.0
+        _SpecularHighlights("Specular Highlights", Float) = 1.0
+
+        [HideInInspector] _BumpScale("Scale", Float) = 1.0
+        [NoScaleOffset] _BumpMap("Normal Map", 2D) = "bump" {}
+
+        [HDR] _EmissionColor("Emission Color", Color) = (0,0,0)
+        [NoScaleOffset]_EmissionMap("Emission Map", 2D) = "white" {}
+
+        _ScanDisColor ("ScanDisColor", Color) = (1,1,1,1)
+        _ScanDisOrigin ("ScanDisOrigin", Vector) = (0,0,0,0)
+        _ScanDisRange ("ScanDisRange", Range(0, 20)) = 1
+
+        // Blending state
+        _Surface("__surface", Float) = 0.0
+        _Blend("__blend", Float) = 0.0
+        _Cull("__cull", Float) = 2.0
+        [ToggleUI] _AlphaClip("__clip", Float) = 0.0
+        [HideInInspector] _SrcBlend("__src", Float) = 1.0
+        [HideInInspector] _DstBlend("__dst", Float) = 0.0
+        [HideInInspector] _SrcBlendAlpha("__srcA", Float) = 1.0
+        [HideInInspector] _DstBlendAlpha("__dstA", Float) = 0.0
+        [HideInInspector] _ZWrite("__zw", Float) = 1.0
+        [HideInInspector] _BlendModePreserveSpecular("_BlendModePreserveSpecular", Float) = 1.0
+        [HideInInspector] _AlphaToMask("__alphaToMask", Float) = 0.0
+
+        [ToggleUI] _ReceiveShadows("Receive Shadows", Float) = 1.0
+        // Editmode props
+        _QueueOffset("Queue offset", Float) = 0.0
+
+        // ObsoleteProperties
+        [HideInInspector] _MainTex("BaseMap", 2D) = "white" {}
+        [HideInInspector] _Color("Base Color", Color) = (1, 1, 1, 1)
+        [HideInInspector] _Shininess("Smoothness", Float) = 0.0
+        [HideInInspector] _GlossinessSource("GlossinessSource", Float) = 0.0
+        [HideInInspector] _SpecSource("SpecularHighlights", Float) = 0.0
+
+        [HideInInspector][NoScaleOffset]unity_Lightmaps("unity_Lightmaps", 2DArray) = "" {}
+        [HideInInspector][NoScaleOffset]unity_LightmapsInd("unity_LightmapsInd", 2DArray) = "" {}
+        [HideInInspector][NoScaleOffset]unity_ShadowMasks("unity_ShadowMasks", 2DArray) = "" {}
+    }
+
+    SubShader
+    {
+        Tags { "RenderType" = "Opaque" "RenderPipeline" = "UniversalPipeline" "UniversalMaterialType" = "SimpleLit" "IgnoreProjector" = "True" "ShaderModel"="4.5"}
+        LOD 300
+
+        Pass
+        {
+            Name "ForwardLit"
+            Tags { "LightMode" = "UniversalForward" }
+
+            // Use same blending / depth states as Standard shader
+            Blend[_SrcBlend][_DstBlend], [_SrcBlendAlpha][_DstBlendAlpha]
+            ZWrite[_ZWrite]
+            Cull[_Cull]
+            AlphaToMask[_AlphaToMask]
+
+            HLSLPROGRAM
+            #pragma exclude_renderers gles gles3 glcore
+            #pragma target 4.5
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local _NORMALMAP
+            #pragma shader_feature_local_fragment _EMISSION
+            #pragma shader_feature_local _RECEIVE_SHADOWS_OFF
+            #pragma shader_feature_local_fragment _SURFACE_TYPE_TRANSPARENT
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _ _ALPHAPREMULTIPLY_ON _ALPHAMODULATE_ON
+            #pragma shader_feature_local_fragment _ _SPECGLOSSMAP _SPECULAR_COLOR
+            #pragma shader_feature_local_fragment _GLOSSINESS_FROM_BASE_ALPHA
+
+            // -------------------------------------
+            // Universal Pipeline keywords
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _MAIN_LIGHT_SHADOWS_SCREEN
+            #pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
+            #pragma multi_compile _ LIGHTMAP_SHADOW_MIXING
+            #pragma multi_compile _ SHADOWS_SHADOWMASK
+            #pragma multi_compile_fragment _ _ADDITIONAL_LIGHT_SHADOWS
+            #pragma multi_compile_fragment _ _SHADOWS_SOFT
+            #pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
+            #pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
+            #pragma multi_compile_fragment _ _LIGHT_LAYERS
+            #pragma multi_compile_fragment _ _LIGHT_COOKIES
+            #pragma multi_compile _ _FORWARD_PLUS
+            #pragma multi_compile_fragment _ _WRITE_RENDERING_LAYERS
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile _ DIRLIGHTMAP_COMBINED
+            #pragma multi_compile _ LIGHTMAP_ON
+            #pragma multi_compile _ DYNAMICLIGHTMAP_ON
+            #pragma multi_compile_fog
+            #pragma multi_compile_fragment _ DEBUG_DISPLAY
+            #pragma multi_compile_fragment _ LOD_FADE_CROSSFADE
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+            #pragma instancing_options renderinglayer
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+
+            #pragma vertex LitPassVertexSimple
+            #pragma fragment LitPassFragmentSimple
+            #define BUMP_SCALE_NOT_SUPPORTED 1
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitInput.hlsl"
+            #include "ScanSimpleLitForwardPass.hlsl"
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "ShadowCaster"
+            Tags{"LightMode" = "ShadowCaster"}
+
+            ZWrite On
+            ZTest LEqual
+            ColorMask 0
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma exclude_renderers gles gles3 glcore
+            #pragma target 4.5
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _GLOSSINESS_FROM_BASE_ALPHA
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+
+            // -------------------------------------
+            // Universal Pipeline keywords
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile_fragment _ LOD_FADE_CROSSFADE
+
+            // This is used during shadow map generation to differentiate between directional and punctual light shadows, as they use different formulas to apply Normal Bias
+            #pragma multi_compile_vertex _ _CASTING_PUNCTUAL_LIGHT_SHADOW
+
+            #pragma vertex ShadowPassVertex
+            #pragma fragment ShadowPassFragment
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/ShadowCasterPass.hlsl"
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "GBuffer"
+            Tags{"LightMode" = "UniversalGBuffer"}
+
+            ZWrite[_ZWrite]
+            ZTest LEqual
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma exclude_renderers gles gles3 glcore
+            #pragma target 4.5
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            //#pragma shader_feature _ALPHAPREMULTIPLY_ON
+            #pragma shader_feature_local_fragment _ _SPECGLOSSMAP _SPECULAR_COLOR
+            #pragma shader_feature_local_fragment _GLOSSINESS_FROM_BASE_ALPHA
+            #pragma shader_feature_local _NORMALMAP
+            #pragma shader_feature_local_fragment _EMISSION
+            #pragma shader_feature_local _RECEIVE_SHADOWS_OFF
+
+            // -------------------------------------
+            // Universal Pipeline keywords
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _MAIN_LIGHT_SHADOWS_SCREEN
+            //#pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
+            //#pragma multi_compile _ _ADDITIONAL_LIGHT_SHADOWS
+            #pragma multi_compile_fragment _ _SHADOWS_SOFT
+            #pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
+            #pragma multi_compile_fragment _ _WRITE_RENDERING_LAYERS
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile _ DIRLIGHTMAP_COMBINED
+            #pragma multi_compile _ LIGHTMAP_ON
+            #pragma multi_compile _ DYNAMICLIGHTMAP_ON
+            #pragma multi_compile _ LIGHTMAP_SHADOW_MIXING
+            #pragma multi_compile _ SHADOWS_SHADOWMASK
+            #pragma multi_compile_fragment _ _GBUFFER_NORMALS_OCT
+            #pragma multi_compile_fragment _ _RENDER_PASS_ENABLED
+            #pragma multi_compile_fragment _ LOD_FADE_CROSSFADE
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+            #pragma instancing_options renderinglayer
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+
+            #pragma vertex LitPassVertexSimple
+            #pragma fragment LitPassFragmentSimple
+            #define BUMP_SCALE_NOT_SUPPORTED 1
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitGBufferPass.hlsl"
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "DepthOnly"
+            Tags{"LightMode" = "DepthOnly"}
+
+            ZWrite On
+            ColorMask R
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma exclude_renderers gles gles3 glcore
+            #pragma target 4.5
+
+            #pragma vertex DepthOnlyVertex
+            #pragma fragment DepthOnlyFragment
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _GLOSSINESS_FROM_BASE_ALPHA
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile_fragment _ LOD_FADE_CROSSFADE
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/DepthOnlyPass.hlsl"
+            ENDHLSL
+        }
+
+        // This pass is used when drawing to a _CameraNormalsTexture texture
+        Pass
+        {
+            Name "DepthNormals"
+            Tags{"LightMode" = "DepthNormals"}
+
+            ZWrite On
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma exclude_renderers gles gles3 glcore
+            #pragma target 4.5
+
+            #pragma vertex DepthNormalsVertex
+            #pragma fragment DepthNormalsFragment
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local _NORMALMAP
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _GLOSSINESS_FROM_BASE_ALPHA
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile_fragment _ LOD_FADE_CROSSFADE
+            // Universal Pipeline keywords
+            #pragma multi_compile_fragment _ _WRITE_RENDERING_LAYERS
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitDepthNormalsPass.hlsl"
+            ENDHLSL
+        }
+
+        // This pass it not used during regular rendering, only for lightmap baking.
+        Pass
+        {
+            Name "Meta"
+            Tags{ "LightMode" = "Meta" }
+
+            Cull Off
+
+            HLSLPROGRAM
+            #pragma exclude_renderers gles gles3 glcore
+            #pragma target 4.5
+
+            #pragma vertex UniversalVertexMeta
+            #pragma fragment UniversalFragmentMetaSimple
+            #pragma shader_feature EDITOR_VISUALIZATION
+
+            #pragma shader_feature_local_fragment _EMISSION
+            #pragma shader_feature_local_fragment _SPECGLOSSMAP
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitMetaPass.hlsl"
+
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "Universal2D"
+            Tags{ "LightMode" = "Universal2D" }
+            Tags{ "RenderType" = "Transparent" "Queue" = "Transparent" }
+
+            HLSLPROGRAM
+            #pragma exclude_renderers gles gles3 glcore
+            #pragma target 4.5
+
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _ALPHAPREMULTIPLY_ON
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/Utils/Universal2D.hlsl"
+            ENDHLSL
+        }
+    }
+
+    SubShader
+    {
+        Tags { "RenderType" = "Opaque" "RenderPipeline" = "UniversalPipeline" "UniversalMaterialType" = "SimpleLit" "IgnoreProjector" = "True" "ShaderModel"="2.0"}
+        LOD 300
+
+        Pass
+        {
+            Name "ForwardLit"
+            Tags { "LightMode" = "UniversalForward" }
+
+            // Use same blending / depth states as Standard shader
+            Blend[_SrcBlend][_DstBlend], [_SrcBlendAlpha][_DstBlendAlpha]
+            ZWrite[_ZWrite]
+            Cull[_Cull]
+            AlphaToMask[_AlphaToMask]
+
+            HLSLPROGRAM
+            #pragma only_renderers gles gles3 glcore d3d11
+            #pragma target 2.0
+
+            // DOTS instancing
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+            #pragma target 3.5 DOTS_INSTANCING_ON
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local _NORMALMAP
+            #pragma shader_feature_local_fragment _EMISSION
+            #pragma shader_feature_local _RECEIVE_SHADOWS_OFF
+            #pragma shader_feature_local_fragment _SURFACE_TYPE_TRANSPARENT
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _ _ALPHAPREMULTIPLY_ON _ALPHAMODULATE_ON
+            #pragma shader_feature_local_fragment _ _SPECGLOSSMAP _SPECULAR_COLOR
+            #pragma shader_feature_local_fragment _GLOSSINESS_FROM_BASE_ALPHA
+
+            // -------------------------------------
+            // Universal Pipeline keywords
+            #pragma multi_compile _ _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _MAIN_LIGHT_SHADOWS_SCREEN
+            #pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
+            #pragma multi_compile _ LIGHTMAP_SHADOW_MIXING
+            #pragma multi_compile _ SHADOWS_SHADOWMASK
+            #pragma multi_compile_fragment _ _SHADOWS_SOFT
+            #pragma multi_compile_fragment _ _ADDITIONAL_LIGHT_SHADOWS
+            #pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
+            #pragma multi_compile_fragment _ _WRITE_RENDERING_LAYERS
+            #pragma multi_compile_fragment _ _LIGHT_COOKIES
+            #pragma multi_compile _ _FORWARD_PLUS
+
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile _ DIRLIGHTMAP_COMBINED
+            #pragma multi_compile _ LIGHTMAP_ON
+            #pragma multi_compile _ DYNAMICLIGHTMAP_ON
+            #pragma multi_compile_fog
+            #pragma multi_compile_fragment _ DEBUG_DISPLAY
+            #pragma multi_compile_fragment _ LOD_FADE_CROSSFADE
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+
+            #pragma vertex LitPassVertexSimple
+            #pragma fragment LitPassFragmentSimple
+            #define BUMP_SCALE_NOT_SUPPORTED 1
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitForwardPass.hlsl"
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "ShadowCaster"
+            Tags{"LightMode" = "ShadowCaster"}
+
+            ZWrite On
+            ZTest LEqual
+            ColorMask 0
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma only_renderers gles gles3 glcore d3d11
+            #pragma target 2.0
+
+            // DOTS instancing
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+            #pragma target 3.5 DOTS_INSTANCING_ON
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _GLOSSINESS_FROM_BASE_ALPHA
+
+            // -------------------------------------
+            // Universal Pipeline keywords
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile_fragment _ LOD_FADE_CROSSFADE
+
+            // This is used during shadow map generation to differentiate between directional and punctual light shadows, as they use different formulas to apply Normal Bias
+            #pragma multi_compile_vertex _ _CASTING_PUNCTUAL_LIGHT_SHADOW
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+
+            #pragma vertex ShadowPassVertex
+            #pragma fragment ShadowPassFragment
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/ShadowCasterPass.hlsl"
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "DepthOnly"
+            Tags{"LightMode" = "DepthOnly"}
+
+            ZWrite On
+            ColorMask R
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma only_renderers gles gles3 glcore d3d11
+            #pragma target 2.0
+
+            // DOTS instancing
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+            #pragma target 3.5 DOTS_INSTANCING_ON
+
+            #pragma vertex DepthOnlyVertex
+            #pragma fragment DepthOnlyFragment
+
+            // Material Keywords
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _GLOSSINESS_FROM_BASE_ALPHA
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile_fragment _ LOD_FADE_CROSSFADE
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/DepthOnlyPass.hlsl"
+            ENDHLSL
+        }
+
+        // This pass is used when drawing to a _CameraNormalsTexture texture
+        Pass
+        {
+            Name "DepthNormals"
+            Tags{"LightMode" = "DepthNormals"}
+
+            ZWrite On
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma only_renderers gles gles3 glcore d3d11
+            #pragma target 2.0
+
+            // DOTS instancing
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+            #pragma target 3.5 DOTS_INSTANCING_ON
+
+            #pragma vertex DepthNormalsVertex
+            #pragma fragment DepthNormalsFragment
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local _NORMALMAP
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _GLOSSINESS_FROM_BASE_ALPHA
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile_fragment _ LOD_FADE_CROSSFADE
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitDepthNormalsPass.hlsl"
+            ENDHLSL
+        }
+
+        // This pass it not used during regular rendering, only for lightmap baking.
+        Pass
+        {
+            Name "Meta"
+            Tags{ "LightMode" =  "Meta" }
+
+            Cull Off
+
+            HLSLPROGRAM
+            #pragma only_renderers gles gles3 glcore d3d11
+            #pragma target 2.0
+
+            #pragma vertex UniversalVertexMeta
+            #pragma fragment UniversalFragmentMetaSimple
+
+            #pragma shader_feature_local_fragment _EMISSION
+            #pragma shader_feature_local_fragment _SPECGLOSSMAP
+            #pragma shader_feature EDITOR_VISUALIZATION
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitMetaPass.hlsl"
+
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "Universal2D"
+            Tags{ "LightMode" = "Universal2D" }
+            Tags{ "RenderType" = "Transparent" "Queue" = "Transparent" }
+
+            HLSLPROGRAM
+            #pragma only_renderers gles gles3 glcore d3d11
+            #pragma target 2.0
+
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _ALPHAPREMULTIPLY_ON
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/SimpleLitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/Utils/Universal2D.hlsl"
+            ENDHLSL
+        }
+    }
+
+    Fallback  "Hidden/Universal Render Pipeline/FallbackError"
+    CustomEditor "UnityEditor.Rendering.Universal.ShaderGUI.SimpleLitShader"
+}

--- a/com.unity.toonshader/Effects/Shaders/ScanSimpleLit.shader.meta
+++ b/com.unity.toonshader/Effects/Shaders/ScanSimpleLit.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: aec01cb74bde9684b843fcc3e19da1d1
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.toonshader/Effects/Shaders/ScanSimpleLitForwardPass.hlsl
+++ b/com.unity.toonshader/Effects/Shaders/ScanSimpleLitForwardPass.hlsl
@@ -1,0 +1,221 @@
+#ifndef SCAN_SIMPLE_LIT_PASS_INCLUDED
+#define SCAN_SIMPLE_LIT_PASS_INCLUDED
+
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+#if defined(LOD_FADE_CROSSFADE)
+    #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/LODCrossFade.hlsl"
+#endif
+
+float4 _ScanDisColor;
+float4 _ScanDisOrigin;
+float _ScanDisRange;
+
+struct Attributes
+{
+    float4 positionOS    : POSITION;
+    float3 normalOS      : NORMAL;
+    float4 tangentOS     : TANGENT;
+    float2 texcoord      : TEXCOORD0;
+    float2 staticLightmapUV    : TEXCOORD1;
+    float2 dynamicLightmapUV    : TEXCOORD2;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
+};
+
+struct Varyings
+{
+    float2 uv                       : TEXCOORD0;
+
+    float3 positionWS                  : TEXCOORD1;    // xyz: posWS
+
+    #ifdef _NORMALMAP
+        half4 normalWS                 : TEXCOORD2;    // xyz: normal, w: viewDir.x
+        half4 tangentWS                : TEXCOORD3;    // xyz: tangent, w: viewDir.y
+        half4 bitangentWS              : TEXCOORD4;    // xyz: bitangent, w: viewDir.z
+    #else
+        half3  normalWS                : TEXCOORD2;
+    #endif
+
+    #ifdef _ADDITIONAL_LIGHTS_VERTEX
+        half4 fogFactorAndVertexLight  : TEXCOORD5; // x: fogFactor, yzw: vertex light
+    #else
+        half  fogFactor                 : TEXCOORD5;
+    #endif
+
+    #if defined(REQUIRES_VERTEX_SHADOW_COORD_INTERPOLATOR)
+        float4 shadowCoord             : TEXCOORD6;
+    #endif
+
+    DECLARE_LIGHTMAP_OR_SH(staticLightmapUV, vertexSH, 7);
+
+#ifdef DYNAMICLIGHTMAP_ON
+    float2  dynamicLightmapUV : TEXCOORD8; // Dynamic lightmap UVs
+#endif
+
+    float4 positionCS                  : SV_POSITION;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
+    UNITY_VERTEX_OUTPUT_STEREO
+};
+
+void InitializeInputData(Varyings input, half3 normalTS, out InputData inputData)
+{
+    inputData = (InputData)0;
+
+    inputData.positionWS = input.positionWS;
+
+    #ifdef _NORMALMAP
+        half3 viewDirWS = half3(input.normalWS.w, input.tangentWS.w, input.bitangentWS.w);
+        inputData.tangentToWorld = half3x3(input.tangentWS.xyz, input.bitangentWS.xyz, input.normalWS.xyz);
+        inputData.normalWS = TransformTangentToWorld(normalTS, inputData.tangentToWorld);
+    #else
+        half3 viewDirWS = GetWorldSpaceNormalizeViewDir(inputData.positionWS);
+        inputData.normalWS = input.normalWS;
+    #endif
+
+    inputData.normalWS = NormalizeNormalPerPixel(inputData.normalWS);
+    viewDirWS = SafeNormalize(viewDirWS);
+
+    inputData.viewDirectionWS = viewDirWS;
+
+    #if defined(REQUIRES_VERTEX_SHADOW_COORD_INTERPOLATOR)
+        inputData.shadowCoord = input.shadowCoord;
+    #elif defined(MAIN_LIGHT_CALCULATE_SHADOWS)
+        inputData.shadowCoord = TransformWorldToShadowCoord(inputData.positionWS);
+    #else
+        inputData.shadowCoord = float4(0, 0, 0, 0);
+    #endif
+
+    #ifdef _ADDITIONAL_LIGHTS_VERTEX
+        inputData.fogCoord = InitializeInputDataFog(float4(inputData.positionWS, 1.0), input.fogFactorAndVertexLight.x);
+        inputData.vertexLighting = input.fogFactorAndVertexLight.yzw;
+    #else
+        inputData.fogCoord = InitializeInputDataFog(float4(inputData.positionWS, 1.0), input.fogFactor);
+        inputData.vertexLighting = half3(0, 0, 0);
+    #endif
+
+#if defined(DYNAMICLIGHTMAP_ON)
+    inputData.bakedGI = SAMPLE_GI(input.staticLightmapUV, input.dynamicLightmapUV, input.vertexSH, inputData.normalWS);
+#else
+    inputData.bakedGI = SAMPLE_GI(input.staticLightmapUV, input.vertexSH, inputData.normalWS);
+#endif
+
+    inputData.normalizedScreenSpaceUV = GetNormalizedScreenSpaceUV(input.positionCS);
+    inputData.shadowMask = SAMPLE_SHADOWMASK(input.staticLightmapUV);
+
+    #if defined(DEBUG_DISPLAY)
+    #if defined(DYNAMICLIGHTMAP_ON)
+    inputData.dynamicLightmapUV = input.dynamicLightmapUV.xy;
+    #endif
+    #if defined(LIGHTMAP_ON)
+    inputData.staticLightmapUV = input.staticLightmapUV;
+    #else
+    inputData.vertexSH = input.vertexSH;
+    #endif
+    #endif
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//                  Vertex and Fragment functions                            //
+///////////////////////////////////////////////////////////////////////////////
+
+// Used in Standard (Simple Lighting) shader
+Varyings LitPassVertexSimple(Attributes input)
+{
+    Varyings output = (Varyings)0;
+
+    UNITY_SETUP_INSTANCE_ID(input);
+    UNITY_TRANSFER_INSTANCE_ID(input, output);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+
+    VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);
+    VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+
+#if defined(_FOG_FRAGMENT)
+        half fogFactor = 0;
+#else
+        half fogFactor = ComputeFogFactor(vertexInput.positionCS.z);
+#endif
+
+    output.uv = TRANSFORM_TEX(input.texcoord, _BaseMap);
+    output.positionWS.xyz = vertexInput.positionWS;
+    output.positionCS = vertexInput.positionCS;
+
+#ifdef _NORMALMAP
+    half3 viewDirWS = GetWorldSpaceViewDir(vertexInput.positionWS);
+    output.normalWS = half4(normalInput.normalWS, viewDirWS.x);
+    output.tangentWS = half4(normalInput.tangentWS, viewDirWS.y);
+    output.bitangentWS = half4(normalInput.bitangentWS, viewDirWS.z);
+#else
+    output.normalWS = NormalizeNormalPerVertex(normalInput.normalWS);
+#endif
+
+    OUTPUT_LIGHTMAP_UV(input.staticLightmapUV, unity_LightmapST, output.staticLightmapUV);
+#ifdef DYNAMICLIGHTMAP_ON
+    output.dynamicLightmapUV = input.dynamicLightmapUV.xy * unity_DynamicLightmapST.xy + unity_DynamicLightmapST.zw;
+#endif
+    OUTPUT_SH(output.normalWS.xyz, output.vertexSH);
+
+    #ifdef _ADDITIONAL_LIGHTS_VERTEX
+        half3 vertexLight = VertexLighting(vertexInput.positionWS, normalInput.normalWS);
+        output.fogFactorAndVertexLight = half4(fogFactor, vertexLight);
+    #else
+        output.fogFactor = fogFactor;
+    #endif
+
+    #if defined(REQUIRES_VERTEX_SHADOW_COORD_INTERPOLATOR)
+        output.shadowCoord = GetShadowCoord(vertexInput);
+    #endif
+
+    return output;
+}
+
+// Used for StandardSimpleLighting shader
+void LitPassFragmentSimple(
+    Varyings input
+    , out half4 outColor : SV_Target0
+#ifdef _WRITE_RENDERING_LAYERS
+    , out float4 outRenderingLayers : SV_Target1
+#endif
+)
+{
+    UNITY_SETUP_INSTANCE_ID(input);
+    UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+
+    //
+    float sdf = distance(input.positionWS.xyz, _ScanDisOrigin.xyz) / _ScanDisRange;
+    float diff = 1.0 - sdf - 0.01;
+    // clip(diff);
+
+    SurfaceData surfaceData;
+    InitializeSimpleLitSurfaceData(input.uv, surfaceData);
+
+#ifdef LOD_FADE_CROSSFADE
+    LODFadeCrossFade(input.positionCS);
+#endif
+
+    InputData inputData;
+    InitializeInputData(input, surfaceData.normalTS, inputData);
+    SETUP_DEBUG_TEXTURE_DATA(inputData, input.uv, _BaseMap);
+
+#ifdef _DBUFFER
+    ApplyDecalToSurfaceData(input.positionCS, surfaceData, inputData);
+#endif
+
+    half4 color = UniversalFragmentBlinnPhong(inputData, surfaceData);
+    color.rgb = MixFog(color.rgb, inputData.fogCoord);
+    color.a = OutputAlpha(color.a, IsSurfaceTypeTransparent(_Surface));
+
+    if (diff < 0.01)
+    {
+        // color = lerp(_ScanDisColor, color, diff * 100);
+    }
+
+    outColor = color;
+
+#ifdef _WRITE_RENDERING_LAYERS
+    uint renderingLayers = GetMeshRenderingLayer();
+    outRenderingLayers = float4(EncodeMeshRenderingLayer(renderingLayers), 0, 0, 0);
+#endif
+}
+
+#endif

--- a/com.unity.toonshader/Effects/Shaders/ScanSimpleLitForwardPass.hlsl.meta
+++ b/com.unity.toonshader/Effects/Shaders/ScanSimpleLitForwardPass.hlsl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 42e45d64d6c77ce4abb26a108994303f
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.toonshader/Effects/Shaders/SceneScanner.shader
+++ b/com.unity.toonshader/Effects/Shaders/SceneScanner.shader
@@ -1,0 +1,102 @@
+Shader "Custom/PP_SceneScanner"
+{
+    Properties
+    {
+        _ScanDisColor ("ScanDisColor", Color) = (1,1,1,1)
+        _ScanDisOrigin ("ScanDisOrigin", Vector) = (0,0,0,0)
+        _ScanDisRange ("ScanDisRange", Range(0, 20)) = 1
+        _Power ("Power", Float) = 8
+    }
+SubShader 
+    {
+        PackageRequirements
+        {
+             "com.unity.render-pipelines.universal": "10.5.0"
+        }    
+        Tags {
+            "RenderType"="Transparent"
+            "Queue"="Transparent+99"
+            "RenderPipeline" = "UniversalPipeline"
+        }
+        Pass {
+            Name "Outline"
+            Tags {
+                "LightMode" = "SRPDefaultUnlit"
+            }
+            ZTest Always
+            ZWrite OFF
+            Cull OFF
+            Blend SrcAlpha OneMinusSrcAlpha
+
+            HLSLPROGRAM
+            #pragma vertex PPVert
+            #pragma fragment PPFrag
+
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Packages/com.unity.render-pipelines.core/Runtime/Utilities/Blit.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DeclareDepthTexture.hlsl"
+
+            SAMPLER(sampler_BlitTexture);
+            float4 _ScanDisColor;
+            float4 _ScanDisOrigin;
+            float _ScanDisRange;
+            float _Power;
+
+
+            struct VaryingsCMB
+            {
+                float4 positionCS    : SV_POSITION;
+                float4 texcoord      : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            VaryingsCMB PPVert(Attributes input)
+            {
+                VaryingsCMB output = (VaryingsCMB)0;
+                UNITY_SETUP_INSTANCE_ID(input);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+#if SHADER_API_GLES
+                float4 pos = input.positionOS;
+                float2 uv  = input.uv;
+#else
+                float4 pos = GetFullScreenTriangleVertexPosition(input.vertexID);
+                float2 uv  = GetFullScreenTriangleTexCoord(input.vertexID);
+#endif
+
+                output.positionCS = pos;
+                output.texcoord.xy = uv;
+
+                float4 projPos = output.positionCS * 0.5;
+                projPos.xy = projPos.xy + projPos.w;
+                output.texcoord.zw = projPos.xy;
+
+                return output;
+            }
+
+            half4 PPFrag(VaryingsCMB input) : SV_TARGET
+            {
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+                float2 uv = UnityStereoTransformScreenSpaceTex(input.texcoord.xy);
+                float depth = SampleSceneDepth(input.texcoord.xy);
+#ifdef UNITY_REVERSED_Z
+				depth = (1.0 - depth);
+#endif
+                depth = 2.0 * depth - 1.0;
+
+                float3 viewPos = ComputeViewSpacePosition(input.texcoord.zw, depth, unity_CameraInvProjection);
+                float4 worldPos = float4(mul(unity_CameraToWorld, float4(viewPos, 1.0)).xyz, 1.0);
+                float sdf = distance(worldPos.xyz, _ScanDisOrigin.xyz) / _ScanDisRange;
+                clip(1.0 - sdf);
+
+                float offset = pow(sdf, _Power);
+                half4 color = _ScanDisColor;
+                color.a = lerp(0, 1, offset);
+
+                return color;
+            }
+
+            ENDHLSL
+        }
+    }
+}

--- a/com.unity.toonshader/Effects/Shaders/SceneScanner.shader.meta
+++ b/com.unity.toonshader/Effects/Shaders/SceneScanner.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 27194035a351ab04b99ef3f803163cde
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.toonshader/Runtime/CustomScripts.meta
+++ b/com.unity.toonshader/Runtime/CustomScripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b11671503ab78364e89782eead3e7a93
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.toonshader/Runtime/CustomScripts/SDFFaceForwardProvider.cs
+++ b/com.unity.toonshader/Runtime/CustomScripts/SDFFaceForwardProvider.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UTSCustom
+{
+    public class SDFFaceForwardProvider : MonoBehaviour
+    {
+        public Transform headFront;
+        public Transform headBack;
+        public Material faceMaterial;
+        private string propertyName = "_FaceForward";
+
+        // Update is called once per frame
+        void Update()
+        {
+            if (headFront != null && headBack != null)
+            {
+                Vector3 dir = headFront.position - headBack.position;
+                faceMaterial.SetVector(propertyName, dir.normalized);
+            }
+        }
+    }
+}

--- a/com.unity.toonshader/Runtime/CustomScripts/SDFFaceForwardProvider.cs.meta
+++ b/com.unity.toonshader/Runtime/CustomScripts/SDFFaceForwardProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 429b69a6529849d46ab39580ccff70d8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToon.shader
+++ b/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToon.shader
@@ -1217,6 +1217,7 @@ Shader "Toon" {
             #pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
             #pragma multi_compile _ _ADDITIONAL_LIGHT_SHADOWS
             #pragma multi_compile _ _SHADOWS_SOFT
+            #pragma multi_compile _ _FORWARD_PLUS
 
             #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
             // -------------------------------------

--- a/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToon.shader
+++ b/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToon.shader
@@ -474,8 +474,8 @@ Shader "Toon" {
 
         /// CUSTOM
         _SDF_Tex("SDF_Tex", 2D) = "white" {}
+        _SDF_Offset("SDF_Offset", Float) = 0
         _FaceForward("Face Forward Vector", Vector) = (0, 0, 1, 0)
-        // [Toggle(_)] _USE_SDF ("USE_SDF", Float ) = 0
 	//////////////////////////////////////////////////////////////////////////////
 	//////////////////// End of HDRP material default values. ////////////////////
 	//////////////////////////////////////////////////////////////////////////////

--- a/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToon.shader
+++ b/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToon.shader
@@ -468,6 +468,14 @@ Shader "Toon" {
         [ToggleUI] _SupportDecals("Support Decals", Float) = 1.0
         [ToggleUI] _ReceivesSSR("Receives SSR", Float) = 1.0
         [ToggleUI] _AddPrecomputedVelocity("AddPrecomputedVelocity", Float) = 0.0
+
+
+
+
+        /// CUSTOM
+        _SDF_Tex("SDF_Tex", 2D) = "white" {}
+        _FaceForward("Face Forward Vector", Vector) = (0, 0, 1, 0)
+        // [Toggle(_)] _USE_SDF ("USE_SDF", Float ) = 0
 	//////////////////////////////////////////////////////////////////////////////
 	//////////////////// End of HDRP material default values. ////////////////////
 	//////////////////////////////////////////////////////////////////////////////
@@ -1241,11 +1249,16 @@ Shader "Toon" {
             #pragma shader_feature _IS_CLIPPING_OFF _IS_CLIPPING_MODE _IS_CLIPPING_TRANSMODE
 
             #pragma shader_feature _EMISSIVE_SIMPLE _EMISSIVE_ANIMATION
+
+            // CUSTOM
+            #pragma shader_feature _USE_SDF
+
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
 #ifdef UNIVERSAL_PIPELINE_CORE_INCLUDED
             #include "../../UniversalRP/Shaders/UniversalToonInput.hlsl"
             #include "Packages/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl"
+            #include "../../UniversalRP/Shaders/UniversalToonFaceSDF.hlsl"
             #include "../../UniversalRP/Shaders/UniversalToonHead.hlsl"
             #include "../../UniversalRP/Shaders/UniversalToonBody.hlsl"
 #endif

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBody.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBody.hlsl
@@ -26,6 +26,26 @@
 #endif
 
 
+#if USE_FORWARD_PLUS && defined(LIGHTMAP_ON) && defined(LIGHTMAP_SHADOW_MIXING)
+#define FORWARD_PLUS_SUBTRACTIVE_LIGHT_CHECK if (_AdditionalLightsColor[loopCounter].a > 0.0h) continue;
+#else
+#define FORWARD_PLUS_SUBTRACTIVE_LIGHT_CHECK
+#endif
+
+#if USE_FORWARD_PLUS
+    #define UTS_LIGHT_LOOP_BEGIN(lightCount) { \
+    uint lightIndex; \
+    ClusterIterator _urp_internal_clusterIterator = ClusterInit(GetNormalizedScreenSpaceUV(i.pos), i.posWorld.xyz, 0); \
+    [loop] while (ClusterNext(_urp_internal_clusterIterator, lightIndex)) { \
+        lightIndex += URP_FP_DIRECTIONAL_LIGHTS_COUNT; \
+        FORWARD_PLUS_SUBTRACTIVE_LIGHT_CHECK
+    #define UTS_LIGHT_LOOP_END } }
+#else
+    #define UTS_LIGHT_LOOP_BEGIN(lightCount) \
+    for (uint loopCounter = 0u; loopCounter < lightCount; ++loopCounter) {
+
+    #define UTS_LIGHT_LOOP_END }
+#endif
 
              
 
@@ -78,7 +98,7 @@
                 outSurfaceData.occlusion = SampleOcclusion(uv);
                 outSurfaceData.emission = SampleEmission(uv, _EmissionColor.rgb, TEXTURE2D_ARGS(_EmissionMap, sampler_EmissionMap));
             }
-            half3 GlobalIlluminationUTS(BRDFData brdfData, half3 bakedGI, half occlusion, half3 normalWS, half3 viewDirectionWS)
+            half3 GlobalIlluminationUTS_Deprecated(BRDFData brdfData, half3 bakedGI, half occlusion, half3 normalWS, half3 viewDirectionWS)
             {
                 half3 reflectVector = reflect(-viewDirectionWS, normalWS);
                 half fresnelTerm = Pow4(1.0 - saturate(dot(normalWS, viewDirectionWS)));
@@ -87,6 +107,20 @@
                 half3 indirectSpecular = GlossyEnvironmentReflection(reflectVector, brdfData.perceptualRoughness, occlusion);
 
                 return EnvironmentBRDF(brdfData, indirectDiffuse, indirectSpecular, fresnelTerm);
+            }
+            half3 GlobalIlluminationUTS(BRDFData brdfData, half3 bakedGI, half occlusion, half3 normalWS, half3 viewDirectionWS, float3 positionWS, float2 normalizedScreenSpaceUV)
+            {
+                half3 reflectVector = reflect(-viewDirectionWS, normalWS);
+                half fresnelTerm = Pow4(1.0 - saturate(dot(normalWS, viewDirectionWS)));
+
+                half3 indirectDiffuse = bakedGI * occlusion;
+#if USE_FORWARD_PLUS
+                half3 irradiance = CalculateIrradianceFromReflectionProbes(reflectVector, positionWS, brdfData.perceptualRoughness, normalizedScreenSpaceUV);
+                half3 indirectSpecular = irradiance * occlusion;
+#else
+                half3 indirectSpecular = GlossyEnvironmentReflection(reflectVector, brdfData.perceptualRoughness, occlusion);
+#endif
+                return EnvironmentBRDF(brdfData, indirectDiffuse, indirectSpecular, fresnelTerm);     
             }
 
             struct VertexInput {
@@ -242,8 +276,16 @@
             {
                 UtsLight light;
                 light.direction = _MainLightPosition.xyz;
+#if USE_FORWARD_PLUS
+                #if defined(LIGHTMAP_ON)
+                    light.distanceAttenuation = _MainLightColor.a;
+                #else
+                    light.distanceAttenuation = 1.0;
+                #endif
+#else
                 // unity_LightData.z is 1 when not culled by the culling mask, otherwise 0.
                 light.distanceAttenuation = unity_LightData.z;
+#endif
 #if defined(LIGHTMAP_ON) || defined(_MIXED_LIGHTING_SUBTRACTIVE)
                 // unity_ProbesOcclusion.x is the mixed light probe occlusion data
                 light.distanceAttenuation *= unity_ProbesOcclusion.x;
@@ -317,7 +359,11 @@
 // index to a perObjectLightIndex
             UtsLight GetAdditionalUtsLight(uint i, float3 positionWS,float4 positionCS)
             {
+#if USE_FORWARD_PLUS
+                int perObjectLightIndex = i;
+#else
                 int perObjectLightIndex = GetPerObjectLightIndex(i);
+#endif
                 return GetAdditionalPerObjectUtsLight(perObjectLightIndex, positionWS, positionCS);
             }
 

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
@@ -75,7 +75,7 @@
                     surfaceData.smoothness,
                     surfaceData.alpha, brdfData);
 
-                half3 envColor = GlobalIlluminationUTS(brdfData, inputData.bakedGI, surfaceData.occlusion, inputData.normalWS, inputData.viewDirectionWS);
+                half3 envColor = GlobalIlluminationUTS(brdfData, inputData.bakedGI, surfaceData.occlusion, inputData.normalWS, inputData.viewDirectionWS, i.posWorld.xyz, GetNormalizedScreenSpaceUV(i.pos));
                 envColor *= 1.8f;
 
                 UtsLight mainLight = GetMainUtsLightByID(i.mainLightID, i.posWorld.xyz, inputData.shadowCoord, i.positionCS);
@@ -252,13 +252,86 @@
 
                 int pixelLightCount = GetAdditionalLightsCount();
 
+#if USE_FORWARD_PLUS
+                for (uint lightIndex = 0; lightIndex < min(URP_FP_DIRECTIONAL_LIGHTS_COUNT, MAX_VISIBLE_LIGHTS); lightIndex++)
+                {
+                    FORWARD_PLUS_SUBTRACTIVE_LIGHT_CHECK
+                    int iLight = lightIndex;
+                    // if (iLight != i.mainLightID)
+                    {
+                        float notDirectional = 1.0f; //_WorldSpaceLightPos0.w of the legacy code.
+
+                        UtsLight additionalLight = GetUrpMainUtsLight(0,0);
+                        additionalLight = GetAdditionalUtsLight(iLight, inputData.positionWS,i.positionCS);
+                        half3 additionalLightColor = GetLightColor(additionalLight);
+                        //					attenuation = light.distanceAttenuation; 
+
+
+                        float3 lightDirection = additionalLight.direction;
+                        //v.2.0.5: 
+                        float3 addPassLightColor = (0.5*dot(lerp(i.normalDir, normalDirection, _Is_NormalMapToBase), lightDirection) + 0.5) * additionalLightColor.rgb;
+                        float  pureIntencity = max(0.001, (0.299*additionalLightColor.r + 0.587*additionalLightColor.g + 0.114*additionalLightColor.b));
+                        float3 lightColor = max(float3(0.0,0.0,0.0), lerp(addPassLightColor, lerp(float3(0.0,0.0,0.0), min(addPassLightColor, addPassLightColor / pureIntencity), notDirectional), _Is_Filter_LightColor));
+                        float3 halfDirection = normalize(viewDirection + lightDirection); // has to be recalced here.
+
+                        //v.2.0.5:
+                        _BaseColor_Step = saturate(_BaseColor_Step + _StepOffset);
+                        _ShadeColor_Step = saturate(_ShadeColor_Step + _StepOffset);
+                        //
+                        //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
+                        float _LightIntensity = lerp(0, (0.299*additionalLightColor.r + 0.587*additionalLightColor.g + 0.114*additionalLightColor.b), notDirectional);
+                        //v.2.0.5: Filtering the high intensity zone of PointLights
+                        float3 Set_LightColor = lightColor;
+                        //
+                        float3 Set_BaseColor = lerp((_BaseColor.rgb*_MainTex_var.rgb*_LightIntensity), ((_BaseColor.rgb*_MainTex_var.rgb)*Set_LightColor), _Is_LightColor_Base);
+                        //v.2.0.5
+                        float4 _1st_ShadeMap_var = lerp(SAMPLE_TEXTURE2D(_1st_ShadeMap, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _1st_ShadeMap)), _MainTex_var, _Use_BaseAs1st);
+                        float3 Set_1st_ShadeColor = lerp((_1st_ShadeColor.rgb*_1st_ShadeMap_var.rgb*_LightIntensity), ((_1st_ShadeColor.rgb*_1st_ShadeMap_var.rgb)*Set_LightColor), _Is_LightColor_1st_Shade);
+                        //v.2.0.5
+                        float4 _2nd_ShadeMap_var = lerp(SAMPLE_TEXTURE2D(_2nd_ShadeMap, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _2nd_ShadeMap)), _1st_ShadeMap_var, _Use_1stAs2nd);
+                        float3 Set_2nd_ShadeColor = lerp((_2nd_ShadeColor.rgb*_2nd_ShadeMap_var.rgb*_LightIntensity), ((_2nd_ShadeColor.rgb*_2nd_ShadeMap_var.rgb)*Set_LightColor), _Is_LightColor_2nd_Shade);
+                        float _HalfLambert_var = 0.5*dot(lerp(i.normalDir, normalDirection, _Is_NormalMapToBase), lightDirection) + 0.5;
+
+                        float4 _Set_2nd_ShadePosition_var = tex2D(_Set_2nd_ShadePosition, TRANSFORM_TEX(Set_UV0, _Set_2nd_ShadePosition));
+                        float4 _Set_1st_ShadePosition_var = tex2D(_Set_1st_ShadePosition, TRANSFORM_TEX(Set_UV0, _Set_1st_ShadePosition));
+
+                        //v.2.0.5:
+                        float Set_FinalShadowMask = saturate((1.0 + ((lerp(_HalfLambert_var, (_HalfLambert_var*saturate(1.0 + _Tweak_SystemShadowsLevel)), _Set_SystemShadowsToBase) - (_BaseColor_Step - _BaseShade_Feather)) * ((1.0 - _Set_1st_ShadePosition_var.rgb).r - 1.0)) / (_BaseColor_Step - (_BaseColor_Step - _BaseShade_Feather))));
+                        //Composition: 3 Basic Colors as finalColor
+                        float3 finalColor = lerp(Set_BaseColor, lerp(Set_1st_ShadeColor, Set_2nd_ShadeColor, saturate((1.0 + ((_HalfLambert_var - (_ShadeColor_Step - _1st2nd_Shades_Feather)) * ((1.0 - _Set_2nd_ShadePosition_var.rgb).r - 1.0)) / (_ShadeColor_Step - (_ShadeColor_Step - _1st2nd_Shades_Feather))))), Set_FinalShadowMask); // Final Color
+
+                        //v.2.0.6: Add HighColor if _Is_Filter_HiCutPointLightColor is False
+
+
+                        float4 _Set_HighColorMask_var = tex2D(_Set_HighColorMask, TRANSFORM_TEX(Set_UV0, _Set_HighColorMask));
+
+                        float _Specular_var = 0.5*dot(halfDirection, lerp(i.normalDir, normalDirection, _Is_NormalMapToHighColor)) + 0.5; //  Specular                
+                        float _TweakHighColorMask_var = (saturate((_Set_HighColorMask_var.g + _Tweak_HighColorMaskLevel))*lerp((1.0 - step(_Specular_var, (1.0 - pow(_HighColor_Power, 5)))), pow(_Specular_var, exp2(lerp(11, 1, _HighColor_Power))), _Is_SpecularToHighColor));
+
+                        float4 _HighColor_Tex_var = tex2D(_HighColor_Tex, TRANSFORM_TEX(Set_UV0, _HighColor_Tex));
+
+                        float3 _HighColor_var = (lerp((_HighColor_Tex_var.rgb*_HighColor.rgb), ((_HighColor_Tex_var.rgb*_HighColor.rgb)*Set_LightColor), _Is_LightColor_HighColor)*_TweakHighColorMask_var);
+
+                        finalColor = finalColor + lerp(lerp(_HighColor_var, (_HighColor_var*((1.0 - Set_FinalShadowMask) + (Set_FinalShadowMask*_TweakHighColorOnShadow))), _Is_UseTweakHighColorOnShadow), float3(0, 0, 0), _Is_Filter_HiCutPointLightColor);
+                        //
+
+                        finalColor = SATURATE_IF_SDR(finalColor);
+
+                        pointLightColor += finalColor;
+                    }
+                }
+#endif  // USE_FORWARD_PLUS
+
                 // determine main light inorder to apply light culling
                 // when the loop counter start from negative value, MAINLIGHT_IS_MAINLIGHT = -1, some compiler doesn't work well.
                 // for (int iLight = MAINLIGHT_IS_MAINLIGHT; iLight < pixelLightCount ; ++iLight)
-                for (int loopCounter = 0; loopCounter < pixelLightCount - MAINLIGHT_IS_MAINLIGHT; ++loopCounter)
-                {
+                UTS_LIGHT_LOOP_BEGIN(pixelLightCount - MAINLIGHT_IS_MAINLIGHT)
+#if USE_FORWARD_PLUS
+                    int iLight = lightIndex;
+#else
                     int iLight = loopCounter + MAINLIGHT_IS_MAINLIGHT;
                     if (iLight != i.mainLightID)
+#endif
                     {
 
 
@@ -326,7 +399,7 @@
                         pointLightColor += finalColor;
                         //	pointLightColor += lightColor;
                     }
-                }
+                UTS_LIGHT_LOOP_END
   
   #endif
 

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
@@ -158,6 +158,14 @@
                 //Composition: 3 Basic Colors as Set_FinalBaseColor
                 float3 Set_FinalBaseColor = lerp(_BaseColor_var,lerp(_Is_LightColor_1st_Shade_var,lerp( (_2nd_ShadeMap_var.rgb*_2nd_ShadeColor.rgb), ((_2nd_ShadeMap_var.rgb*_2nd_ShadeColor.rgb)*Set_LightColor), _Is_LightColor_2nd_Shade ),Set_ShadeShadowMask),Set_FinalShadowMask);
 
+                // Apply SDF
+#if _USE_SDF
+                half sdfAtten = GetFaceSDFAtten(lightDirection, _FaceForward.xyz, Set_UV0);
+                Set_FinalBaseColor = lerp(_1st_ShadeMap_var, Set_BaseColor, sdfAtten);
+#endif
+
+
+
                 float4 _Set_HighColorMask_var = tex2D(_Set_HighColorMask, TRANSFORM_TEX(Set_UV0, _Set_HighColorMask));
 
                 float _Specular_var = 0.5*dot(halfDirection,lerp( i.normalDir, normalDirection, _Is_NormalMapToHighColor ))+0.5; // Specular

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
@@ -71,7 +71,7 @@
                     surfaceData.smoothness,
                     surfaceData.alpha, brdfData);
 
-                half3 envColor = GlobalIlluminationUTS(brdfData, inputData.bakedGI, surfaceData.occlusion, inputData.normalWS, inputData.viewDirectionWS);
+                half3 envColor = GlobalIlluminationUTS(brdfData, inputData.bakedGI, surfaceData.occlusion, inputData.normalWS, inputData.viewDirectionWS, i.posWorld.xyz, GetNormalizedScreenSpaceUV(i.pos));
                 envColor *= 1.8f;
 
                 UtsLight mainLight = GetMainUtsLightByID(i.mainLightID, i.posWorld.xyz, inputData.shadowCoord, i.positionCS);
@@ -317,14 +317,105 @@
 
                 int pixelLightCount = GetAdditionalLightsCount();
 
+#if USE_FORWARD_PLUS
+                for (uint loopCounter = 0; loopCounter < min(URP_FP_DIRECTIONAL_LIGHTS_COUNT, MAX_VISIBLE_LIGHTS); loopCounter++)
+                {
+                    int iLight = loopCounter;
+                    // if (iLight != i.mainLightID)
+                    {
+                        float notDirectional = 1.0f; //_WorldSpaceLightPos0.w of the legacy code.
+                        UtsLight additionalLight = GetUrpMainUtsLight(0,0);
+                        additionalLight = GetAdditionalUtsLight(loopCounter, inputData.positionWS, i.positionCS);
+                        half3 additionalLightColor = GetLightColor(additionalLight);
+
+                        float3 lightDirection = additionalLight.direction;
+                        //v.2.0.5: 
+                        float3 addPassLightColor = (0.5*dot(lerp(i.normalDir, normalDirection, _Is_NormalMapToBase), lightDirection) + 0.5) * additionalLightColor.rgb;
+                        float  pureIntencity = max(0.001, (0.299*additionalLightColor.r + 0.587*additionalLightColor.g + 0.114*additionalLightColor.b));
+                        float3 lightColor = max(float3(0.0,0.0,0.0), lerp(addPassLightColor, lerp(float3(0.0,0.0,0.0), min(addPassLightColor, addPassLightColor / pureIntencity), notDirectional), _Is_Filter_LightColor));
+                        float3 halfDirection = normalize(viewDirection + lightDirection); // has to be recalced here.
+
+                        //v.2.0.5:
+                        _1st_ShadeColor_Step = saturate(_1st_ShadeColor_Step + _StepOffset);
+                        _2nd_ShadeColor_Step = saturate(_2nd_ShadeColor_Step + _StepOffset);
+                        //
+                        //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
+                        float _LightIntensity = lerp(0, (0.299*additionalLightColor.r + 0.587*additionalLightColor.g + 0.114*additionalLightColor.b), notDirectional);
+                        //v.2.0.5: Filtering the high intensity zone of PointLights
+                        float3 Set_LightColor = lightColor;
+                        //
+                        float3 Set_BaseColor = lerp((_BaseColor.rgb*_MainTex_var.rgb*_LightIntensity), ((_BaseColor.rgb*_MainTex_var.rgb)*Set_LightColor), _Is_LightColor_Base);
+                        //v.2.0.5
+                        float4 _1st_ShadeMap_var = lerp(SAMPLE_TEXTURE2D(_1st_ShadeMap, sampler_MainTex,TRANSFORM_TEX(Set_UV0, _1st_ShadeMap)), _MainTex_var, _Use_BaseAs1st);
+                        float3 Set_1st_ShadeColor = lerp((_1st_ShadeColor.rgb*_1st_ShadeMap_var.rgb*_LightIntensity), ((_1st_ShadeColor.rgb*_1st_ShadeMap_var.rgb)*Set_LightColor), _Is_LightColor_1st_Shade);
+                        //v.2.0.5
+                        float4 _2nd_ShadeMap_var = lerp(SAMPLE_TEXTURE2D(_2nd_ShadeMap, sampler_MainTex,TRANSFORM_TEX(Set_UV0, _2nd_ShadeMap)), _1st_ShadeMap_var, _Use_1stAs2nd);
+                        float3 Set_2nd_ShadeColor = lerp((_2nd_ShadeColor.rgb*_2nd_ShadeMap_var.rgb*_LightIntensity), ((_2nd_ShadeColor.rgb*_2nd_ShadeMap_var.rgb)*Set_LightColor), _Is_LightColor_2nd_Shade);
+                        float _HalfLambert_var = 0.5*dot(lerp(i.normalDir, normalDirection, _Is_NormalMapToBase), lightDirection) + 0.5;
+
+                        // float4 _Set_2nd_ShadePosition_var = tex2D(_Set_2nd_ShadePosition, TRANSFORM_TEX(Set_UV0, _Set_2nd_ShadePosition));
+                        // float4 _Set_1st_ShadePosition_var = tex2D(_Set_1st_ShadePosition, TRANSFORM_TEX(Set_UV0, _Set_1st_ShadePosition));
+                        // //v.2.0.5:
+                        // float Set_FinalShadowMask = saturate((1.0 + ((lerp(_HalfLambert_var, (_HalfLambert_var*saturate(1.0 + _Tweak_SystemShadowsLevel)), _Set_SystemShadowsToBase) - (_1st_ShadeColor_Step - _1st_ShadeColor_Feather)) * ((1.0 - _Set_1st_ShadePosition_var.rgb).r - 1.0)) / (_1st_ShadeColor_Step - (_1st_ShadeColor_Step - _1st_ShadeColor_Feather))));
+    //SGM
+
+                    //v.2.0.6
+                        float4 _ShadingGradeMap_var = tex2Dlod(_ShadingGradeMap, float4(TRANSFORM_TEX(Set_UV0, _ShadingGradeMap), 0.0, _BlurLevelSGM));
+                        //v.2.0.6
+                        //Minmimum value is same as the Minimum Feather's value with the Minimum Step's value as threshold.
+                        //float _SystemShadowsLevel_var = (attenuation*0.5)+0.5+_Tweak_SystemShadowsLevel > 0.001 ? (attenuation*0.5)+0.5+_Tweak_SystemShadowsLevel : 0.0001;
+                        float _ShadingGradeMapLevel_var = _ShadingGradeMap_var.r < 0.95 ? _ShadingGradeMap_var.r + _Tweak_ShadingGradeMapLevel : 1;
+
+                        //float Set_ShadingGrade = saturate(_ShadingGradeMapLevel_var)*lerp( _HalfLambert_var, (_HalfLambert_var*saturate(_SystemShadowsLevel_var)), _Set_SystemShadowsToBase );
+
+                        float Set_ShadingGrade = saturate(_ShadingGradeMapLevel_var)*lerp(_HalfLambert_var, (_HalfLambert_var*saturate(1.0 + _Tweak_SystemShadowsLevel)), _Set_SystemShadowsToBase);
+
+                        //
+                        float Set_FinalShadowMask = saturate((1.0 + ((Set_ShadingGrade - (_1st_ShadeColor_Step - _1st_ShadeColor_Feather)) * (0.0 - 1.0)) / (_1st_ShadeColor_Step - (_1st_ShadeColor_Step - _1st_ShadeColor_Feather))));
+                        float Set_ShadeShadowMask = saturate((1.0 + ((Set_ShadingGrade - (_2nd_ShadeColor_Step - _2nd_ShadeColor_Feather)) * (0.0 - 1.0)) / (_2nd_ShadeColor_Step - (_2nd_ShadeColor_Step - _2nd_ShadeColor_Feather)))); // 1st and 2nd Shades Mask
+
+                        //Composition: 3 Basic Colors as finalColor
+                        float3 finalColor =
+                            lerp(
+                                Set_BaseColor,
+                                //_BaseColor_var*(Set_LightColor*1.5),
+
+                                lerp(
+                                    Set_1st_ShadeColor,
+                                    Set_2nd_ShadeColor,
+                                    Set_ShadeShadowMask
+                                ),
+                                Set_FinalShadowMask);
+                        //v.2.0.6: Add HighColor if _Is_Filter_HiCutPointLightColor is False
+
+                        float4 _Set_HighColorMask_var = tex2D(_Set_HighColorMask, TRANSFORM_TEX(Set_UV0, _Set_HighColorMask));
+                        float _Specular_var = 0.5*dot(halfDirection, lerp(i.normalDir, normalDirection, _Is_NormalMapToHighColor)) + 0.5; //  Specular                
+                        float _TweakHighColorMask_var = (saturate((_Set_HighColorMask_var.g + _Tweak_HighColorMaskLevel))*lerp((1.0 - step(_Specular_var, (1.0 - pow(abs(_HighColor_Power), 5)))), pow(abs(_Specular_var), exp2(lerp(11, 1, _HighColor_Power))), _Is_SpecularToHighColor));
+
+                        float4 _HighColor_Tex_var = tex2D(_HighColor_Tex, TRANSFORM_TEX(Set_UV0, _HighColor_Tex));
+
+                        float3 _HighColor_var = (lerp((_HighColor_Tex_var.rgb*_HighColor.rgb), ((_HighColor_Tex_var.rgb*_HighColor.rgb)*Set_LightColor), _Is_LightColor_HighColor)*_TweakHighColorMask_var);
+
+                        finalColor = finalColor + lerp(lerp(_HighColor_var, (_HighColor_var*((1.0 - Set_FinalShadowMask) + (Set_FinalShadowMask*_TweakHighColorOnShadow))), _Is_UseTweakHighColorOnShadow), float3(0, 0, 0), _Is_Filter_HiCutPointLightColor);
+                        //
+
+                        finalColor = SATURATE_IF_SDR(finalColor);
+
+                        pointLightColor +=  finalColor;
+                    }
+                }
+#endif  // USE_FORWARD_PLUS
   // determine main light inorder to apply light culling properly
   
                 // when the loop counter start from negative value, MAINLIGHT_IS_MAINLIGHT = -1, some compiler doesn't work well.
                 // for (int iLight = MAINLIGHT_IS_MAINLIGHT; iLight < pixelLightCount ; ++iLight)
-                for (int loopCounter = 0; loopCounter < pixelLightCount - MAINLIGHT_IS_MAINLIGHT; ++loopCounter)
-                {
+                UTS_LIGHT_LOOP_BEGIN(pixelLightCount - MAINLIGHT_IS_MAINLIGHT)
+#if USE_FORWARD_PLUS
+                    int iLight = lightIndex;
+#else
                     int iLight = loopCounter + MAINLIGHT_IS_MAINLIGHT;
                     if (iLight != i.mainLightID)
+#endif
                     {
                         float notDirectional = 1.0f; //_WorldSpaceLightPos0.w of the legacy code.
                         UtsLight additionalLight = GetUrpMainUtsLight(0,0);
@@ -431,7 +522,7 @@
                         pointLightColor +=  finalColor;
                         //	pointLightColor += lightColor;
                     }
-                }
+                UTS_LIGHT_LOOP_END
 
   #endif // _ADDITIONAL_LIGHTS
 

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonFaceSDF.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonFaceSDF.hlsl
@@ -1,0 +1,38 @@
+#ifndef UNIVERSAL_TOON_FACE_SDF_INCLUDED
+#define UNIVERSAL_TOON_FACE_SDF_INCLUDED
+
+// Required Uniforms:
+// 1. _SDF_Tex
+// 2. _FaceForward
+
+half GetFaceSDFAtten(float3 lightDir, float3 normal, float2 uv)
+{
+    half NoL = dot(lightDir.xz, normal.xz);
+
+    // Find flip x
+    half2 right = (-lightDir.z, lightDir.x);    // rotate 90 degree
+    half flip_x = ceil(dot(right, normal.xz));
+    uv.x = lerp(-uv.x, uv.x, flip_x);
+
+    // Blur
+    float offset = 0.005;
+    half _SDF_var = SAMPLE_TEXTURE2D(_SDF_Tex, sampler_SDF_Tex, TRANSFORM_TEX(uv, _SDF_Tex)).r;
+    _SDF_var += SAMPLE_TEXTURE2D(_SDF_Tex, sampler_SDF_Tex, TRANSFORM_TEX(uv + float2(offset, offset), _SDF_Tex)).r;
+    _SDF_var += SAMPLE_TEXTURE2D(_SDF_Tex, sampler_SDF_Tex, TRANSFORM_TEX(uv + float2(0.0, offset), _SDF_Tex)).r;
+    _SDF_var += SAMPLE_TEXTURE2D(_SDF_Tex, sampler_SDF_Tex, TRANSFORM_TEX(uv + float2(-offset, offset), _SDF_Tex)).r;
+    _SDF_var += SAMPLE_TEXTURE2D(_SDF_Tex, sampler_SDF_Tex, TRANSFORM_TEX(uv + float2(offset, 0.0), _SDF_Tex)).r;
+    _SDF_var += SAMPLE_TEXTURE2D(_SDF_Tex, sampler_SDF_Tex, TRANSFORM_TEX(uv + float2(-offset, 0.0), _SDF_Tex)).r;
+    _SDF_var += SAMPLE_TEXTURE2D(_SDF_Tex, sampler_SDF_Tex, TRANSFORM_TEX(uv + float2(-offset, -offset), _SDF_Tex)).r;
+    _SDF_var += SAMPLE_TEXTURE2D(_SDF_Tex, sampler_SDF_Tex, TRANSFORM_TEX(uv + float2(0.0, -offset), _SDF_Tex)).r;
+    _SDF_var += SAMPLE_TEXTURE2D(_SDF_Tex, sampler_SDF_Tex, TRANSFORM_TEX(uv + float2(offset, -offset), _SDF_Tex)).r;
+    _SDF_var /= 9.0;
+    
+    // 1-x
+    _SDF_var = 1.0 - _SDF_var;
+    
+    return (0.0, 1.0, _SDF_var <= NoL);
+}
+
+
+
+#endif // UNIVERSAL_TOON_FACE_SDF_INCLUDED

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonFaceSDF.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonFaceSDF.hlsl
@@ -3,15 +3,18 @@
 
 // Required Uniforms:
 // 1. _SDF_Tex
-// 2. _FaceForward
+// 2. _SDF_Offset
+// 3. _FaceForward
 
 half GetFaceSDFAtten(float3 lightDir, float3 normal, float2 uv)
 {
-    half NoL = dot(lightDir.xz, normal.xz);
+    half2 l = normalize(lightDir.xz);
+    half2 n = normalize(normal.xz);
+    half NoL = dot(l, n);
 
     // Find flip x
-    half2 right = (-lightDir.z, lightDir.x);    // rotate 90 degree
-    half flip_x = ceil(dot(right, normal.xz));
+    half2 right = (-l.y, l.x);    // rotate 90 degree
+    half flip_x = ceil(dot(right, n));
     uv.x = lerp(-uv.x, uv.x, flip_x);
 
     // Blur
@@ -30,7 +33,7 @@ half GetFaceSDFAtten(float3 lightDir, float3 normal, float2 uv)
     // 1-x
     _SDF_var = 1.0 - _SDF_var;
     
-    return (0.0, 1.0, _SDF_var <= NoL);
+    return (0.0, 1.0, _SDF_var + _SDF_Offset <= NoL);
 }
 
 

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonFaceSDF.hlsl.meta
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonFaceSDF.hlsl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9a0a015021500f24e9eb02a72dd6c413
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonInput.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonInput.hlsl
@@ -187,6 +187,7 @@ half _Surface;
 
 // CUSTOM
 float4 _SDF_Tex_ST;
+half _SDF_Offset;
 half4 _FaceForward;
 /// CUSTOM END
 

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonInput.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonInput.hlsl
@@ -185,6 +185,11 @@ half _OcclusionStrength;
 half _Surface;
 
 
+// CUSTOM
+float4 _SDF_Tex_ST;
+half4 _FaceForward;
+/// CUSTOM END
+
 CBUFFER_END
 
 //sampler2D _MainTex;
@@ -220,6 +225,10 @@ TEXTURE2D(_OcclusionMap);       SAMPLER(sampler_OcclusionMap);
 TEXTURE2D(_MetallicGlossMap);   SAMPLER(sampler_MetallicGlossMap);
 TEXTURE2D(_SpecGlossMap);       SAMPLER(sampler_SpecGlossMap);
 
+
+/// CUSTOM
+TEXTURE2D(_SDF_Tex);       SAMPLER(sampler_SDF_Tex);
+/// CUSTOM END
 
 #ifdef _SPECULAR_SETUP
 #define SAMPLE_METALLICSPECULAR(uv) SAMPLE_TEXTURE2D(_SpecGlossMap, sampler_SpecGlossMap, uv)


### PR DESCRIPTION
Added a keyword and new GlobalIlluminationUTS function to support Forward+ (Marked the original function as deprecated arbitrarily, please remove or rename it as you wish.)

And I added UTS_LIGHT_LOOP_BEGIN macro for additional lights as well, with a quite long code to support additional directional lights without modularization in case it would violate the code convention...