### PR TITLE
Fix Forward+ Compatibility

### DIFF
--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBody.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBody.hlsl
@@ -122,20 +122,6 @@
 #endif
                 return EnvironmentBRDF(brdfData, indirectDiffuse, indirectSpecular, fresnelTerm);     
             }
-            half3 GlobalIlluminationUTS(BRDFData brdfData, half3 bakedGI, half occlusion, half3 normalWS, half3 viewDirectionWS, float3 positionWS, float2 normalizedScreenSpaceUV)
-            {
-                half3 reflectVector = reflect(-viewDirectionWS, normalWS);
-                half fresnelTerm = Pow4(1.0 - saturate(dot(normalWS, viewDirectionWS)));
-
-                half3 indirectDiffuse = bakedGI * occlusion;
-#if USE_FORWARD_PLUS
-                half3 irradiance = CalculateIrradianceFromReflectionProbes(reflectVector, positionWS, brdfData.perceptualRoughness, normalizedScreenSpaceUV);
-                half3 indirectSpecular = irradiance * occlusion;
-#else
-                half3 indirectSpecular = GlossyEnvironmentReflection(reflectVector, brdfData.perceptualRoughness, occlusion);
-#endif
-                return EnvironmentBRDF(brdfData, indirectDiffuse, indirectSpecular, fresnelTerm);     
-            }
 
             struct VertexInput {
                 float4 vertex : POSITION;

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBody.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBody.hlsl
@@ -35,7 +35,7 @@
 #if USE_FORWARD_PLUS
     #define UTS_LIGHT_LOOP_BEGIN(lightCount) { \
     uint lightIndex; \
-    ClusterIterator _urp_internal_clusterIterator = ClusterInit(GetNormalizedScreenSpaceUV(i.pos), i.posWorld.xyz, 0); \
+    ClusterIterator _urp_internal_clusterIterator = ClusterInit(inputData.normalizedScreenSpaceUV, i.posWorld.xyz, 0); \
     [loop] while (ClusterNext(_urp_internal_clusterIterator, lightIndex)) { \
         lightIndex += URP_FP_DIRECTIONAL_LIGHTS_COUNT; \
         FORWARD_PLUS_SUBTRACTIVE_LIGHT_CHECK

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBody.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBody.hlsl
@@ -283,16 +283,8 @@
                     light.distanceAttenuation = 1.0;
                 #endif
 #else
-#if USE_FORWARD_PLUS
-                #if defined(LIGHTMAP_ON)
-                    light.distanceAttenuation = _MainLightColor.a;
-                #else
-                    light.distanceAttenuation = 1.0;
-                #endif
-#else
                 // unity_LightData.z is 1 when not culled by the culling mask, otherwise 0.
                 light.distanceAttenuation = unity_LightData.z;
-#endif
 #endif
 #if defined(LIGHTMAP_ON) || defined(_MIXED_LIGHTING_SUBTRACTIVE)
                 // unity_ProbesOcclusion.x is the mixed light probe occlusion data
@@ -370,11 +362,7 @@
 #if USE_FORWARD_PLUS
                 int perObjectLightIndex = i;
 #else
-#if USE_FORWARD_PLUS
-                int perObjectLightIndex = i;
-#else
                 int perObjectLightIndex = GetPerObjectLightIndex(i);
-#endif
 #endif
                 return GetAdditionalPerObjectUtsLight(perObjectLightIndex, positionWS, positionCS);
             }

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
@@ -333,7 +333,6 @@
                     int iLight = loopCounter + MAINLIGHT_IS_MAINLIGHT;
                     if (iLight != i.mainLightID)
 #endif
-#endif
                     {
 
 

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
@@ -39,6 +39,7 @@
                 input.vertexSH = i.vertexSH;
 # endif
                 input.uv = i.uv0;
+                input.positionCS = i.pos;
 #  if defined(_ADDITIONAL_LIGHTS_VERTEX) ||  (VERSION_LOWER(12, 0))  
 
 				input.fogFactorAndVertexLight = i.fogFactorAndVertexLight;
@@ -75,7 +76,7 @@
                     surfaceData.smoothness,
                     surfaceData.alpha, brdfData);
 
-                half3 envColor = GlobalIlluminationUTS(brdfData, inputData.bakedGI, surfaceData.occlusion, inputData.normalWS, inputData.viewDirectionWS, i.posWorld.xyz, GetNormalizedScreenSpaceUV(i.pos));
+                half3 envColor = GlobalIlluminationUTS(brdfData, inputData.bakedGI, surfaceData.occlusion, inputData.normalWS, inputData.viewDirectionWS, i.posWorld.xyz, inputData.normalizedScreenSpaceUV);
                 envColor *= 1.8f;
 
                 UtsLight mainLight = GetMainUtsLightByID(i.mainLightID, i.posWorld.xyz, inputData.shadowCoord, i.positionCS);
@@ -275,8 +276,8 @@
                         float3 halfDirection = normalize(viewDirection + lightDirection); // has to be recalced here.
 
                         //v.2.0.5:
-                        _BaseColor_Step = saturate(_BaseColor_Step + _StepOffset);
-                        _ShadeColor_Step = saturate(_ShadeColor_Step + _StepOffset);
+                        float baseColorStep = saturate(_BaseColor_Step + _StepOffset);
+                        float shadeColorStep = saturate(_ShadeColor_Step + _StepOffset);
                         //
                         //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
                         float _LightIntensity = lerp(0, (0.299*additionalLightColor.r + 0.587*additionalLightColor.g + 0.114*additionalLightColor.b), notDirectional);
@@ -296,9 +297,9 @@
                         float4 _Set_1st_ShadePosition_var = tex2D(_Set_1st_ShadePosition, TRANSFORM_TEX(Set_UV0, _Set_1st_ShadePosition));
 
                         //v.2.0.5:
-                        float Set_FinalShadowMask = saturate((1.0 + ((lerp(_HalfLambert_var, (_HalfLambert_var*saturate(1.0 + _Tweak_SystemShadowsLevel)), _Set_SystemShadowsToBase) - (_BaseColor_Step - _BaseShade_Feather)) * ((1.0 - _Set_1st_ShadePosition_var.rgb).r - 1.0)) / (_BaseColor_Step - (_BaseColor_Step - _BaseShade_Feather))));
+                        float Set_FinalShadowMask = saturate((1.0 + ((lerp(_HalfLambert_var, (_HalfLambert_var*saturate(1.0 + _Tweak_SystemShadowsLevel)), _Set_SystemShadowsToBase) - (baseColorStep - _BaseShade_Feather)) * ((1.0 - _Set_1st_ShadePosition_var.rgb).r - 1.0)) / (baseColorStep - (baseColorStep - _BaseShade_Feather))));
                         //Composition: 3 Basic Colors as finalColor
-                        float3 finalColor = lerp(Set_BaseColor, lerp(Set_1st_ShadeColor, Set_2nd_ShadeColor, saturate((1.0 + ((_HalfLambert_var - (_ShadeColor_Step - _1st2nd_Shades_Feather)) * ((1.0 - _Set_2nd_ShadePosition_var.rgb).r - 1.0)) / (_ShadeColor_Step - (_ShadeColor_Step - _1st2nd_Shades_Feather))))), Set_FinalShadowMask); // Final Color
+                        float3 finalColor = lerp(Set_BaseColor, lerp(Set_1st_ShadeColor, Set_2nd_ShadeColor, saturate((1.0 + ((_HalfLambert_var - (shadeColorStep - _1st2nd_Shades_Feather)) * ((1.0 - _Set_2nd_ShadePosition_var.rgb).r - 1.0)) / (shadeColorStep - (shadeColorStep - _1st2nd_Shades_Feather))))), Set_FinalShadowMask); // Final Color
 
                         //v.2.0.6: Add HighColor if _Is_Filter_HiCutPointLightColor is False
 
@@ -354,8 +355,8 @@
                         float3 halfDirection = normalize(viewDirection + lightDirection); // has to be recalced here.
 
                         //v.2.0.5:
-                        _BaseColor_Step = saturate(_BaseColor_Step + _StepOffset);
-                        _ShadeColor_Step = saturate(_ShadeColor_Step + _StepOffset);
+                        float baseColorStep = saturate(_BaseColor_Step + _StepOffset);
+                        float shadeColorStep = saturate(_ShadeColor_Step + _StepOffset);
                         //
                         //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
                         float _LightIntensity = lerp(0, (0.299*additionalLightColor.r + 0.587*additionalLightColor.g + 0.114*additionalLightColor.b), notDirectional);
@@ -375,9 +376,9 @@
                         float4 _Set_1st_ShadePosition_var = tex2D(_Set_1st_ShadePosition, TRANSFORM_TEX(Set_UV0, _Set_1st_ShadePosition));
 
                         //v.2.0.5:
-                        float Set_FinalShadowMask = saturate((1.0 + ((lerp(_HalfLambert_var, (_HalfLambert_var*saturate(1.0 + _Tweak_SystemShadowsLevel)), _Set_SystemShadowsToBase) - (_BaseColor_Step - _BaseShade_Feather)) * ((1.0 - _Set_1st_ShadePosition_var.rgb).r - 1.0)) / (_BaseColor_Step - (_BaseColor_Step - _BaseShade_Feather))));
+                        float Set_FinalShadowMask = saturate((1.0 + ((lerp(_HalfLambert_var, (_HalfLambert_var*saturate(1.0 + _Tweak_SystemShadowsLevel)), _Set_SystemShadowsToBase) - (baseColorStep - _BaseShade_Feather)) * ((1.0 - _Set_1st_ShadePosition_var.rgb).r - 1.0)) / (baseColorStep - (baseColorStep - _BaseShade_Feather))));
                         //Composition: 3 Basic Colors as finalColor
-                        float3 finalColor = lerp(Set_BaseColor, lerp(Set_1st_ShadeColor, Set_2nd_ShadeColor, saturate((1.0 + ((_HalfLambert_var - (_ShadeColor_Step - _1st2nd_Shades_Feather)) * ((1.0 - _Set_2nd_ShadePosition_var.rgb).r - 1.0)) / (_ShadeColor_Step - (_ShadeColor_Step - _1st2nd_Shades_Feather))))), Set_FinalShadowMask); // Final Color
+                        float3 finalColor = lerp(Set_BaseColor, lerp(Set_1st_ShadeColor, Set_2nd_ShadeColor, saturate((1.0 + ((_HalfLambert_var - (shadeColorStep - _1st2nd_Shades_Feather)) * ((1.0 - _Set_2nd_ShadePosition_var.rgb).r - 1.0)) / (shadeColorStep - (shadeColorStep - _1st2nd_Shades_Feather))))), Set_FinalShadowMask); // Final Color
 
                         //v.2.0.6: Add HighColor if _Is_Filter_HiCutPointLightColor is False
 

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
@@ -36,6 +36,7 @@
                 input.vertexSH = i.vertexSH;
 # endif
                 input.uv = i.uv0;
+                input.positionCS = i.pos;
 #  if defined(_ADDITIONAL_LIGHTS_VERTEX) ||  (VERSION_LOWER(12, 0))  
 
                 input.fogFactorAndVertexLight = i.fogFactorAndVertexLight;
@@ -71,7 +72,7 @@
                     surfaceData.smoothness,
                     surfaceData.alpha, brdfData);
 
-                half3 envColor = GlobalIlluminationUTS(brdfData, inputData.bakedGI, surfaceData.occlusion, inputData.normalWS, inputData.viewDirectionWS, i.posWorld.xyz, GetNormalizedScreenSpaceUV(i.pos));
+                half3 envColor = GlobalIlluminationUTS(brdfData, inputData.bakedGI, surfaceData.occlusion, inputData.normalWS, inputData.viewDirectionWS, i.posWorld.xyz, inputData.normalizedScreenSpaceUV);
                 envColor *= 1.8f;
 
                 UtsLight mainLight = GetMainUtsLightByID(i.mainLightID, i.posWorld.xyz, inputData.shadowCoord, i.positionCS);
@@ -336,8 +337,8 @@
                         float3 halfDirection = normalize(viewDirection + lightDirection); // has to be recalced here.
 
                         //v.2.0.5:
-                        _1st_ShadeColor_Step = saturate(_1st_ShadeColor_Step + _StepOffset);
-                        _2nd_ShadeColor_Step = saturate(_2nd_ShadeColor_Step + _StepOffset);
+                        float firstShadeColorStep = saturate(_1st_ShadeColor_Step + _StepOffset);
+                        float secondShadeColorStep = saturate(_2nd_ShadeColor_Step + _StepOffset);
                         //
                         //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
                         float _LightIntensity = lerp(0, (0.299*additionalLightColor.r + 0.587*additionalLightColor.g + 0.114*additionalLightColor.b), notDirectional);
@@ -371,8 +372,8 @@
                         float Set_ShadingGrade = saturate(_ShadingGradeMapLevel_var)*lerp(_HalfLambert_var, (_HalfLambert_var*saturate(1.0 + _Tweak_SystemShadowsLevel)), _Set_SystemShadowsToBase);
 
                         //
-                        float Set_FinalShadowMask = saturate((1.0 + ((Set_ShadingGrade - (_1st_ShadeColor_Step - _1st_ShadeColor_Feather)) * (0.0 - 1.0)) / (_1st_ShadeColor_Step - (_1st_ShadeColor_Step - _1st_ShadeColor_Feather))));
-                        float Set_ShadeShadowMask = saturate((1.0 + ((Set_ShadingGrade - (_2nd_ShadeColor_Step - _2nd_ShadeColor_Feather)) * (0.0 - 1.0)) / (_2nd_ShadeColor_Step - (_2nd_ShadeColor_Step - _2nd_ShadeColor_Feather)))); // 1st and 2nd Shades Mask
+                        float Set_FinalShadowMask = saturate((1.0 + ((Set_ShadingGrade - (firstShadeColorStep - _1st_ShadeColor_Feather)) * (0.0 - 1.0)) / (firstShadeColorStep - (firstShadeColorStep - _1st_ShadeColor_Feather))));
+                        float Set_ShadeShadowMask = saturate((1.0 + ((Set_ShadingGrade - (secondShadeColorStep - _2nd_ShadeColor_Feather)) * (0.0 - 1.0)) / (secondShadeColorStep - (secondShadeColorStep - _2nd_ShadeColor_Feather)))); // 1st and 2nd Shades Mask
 
                         //Composition: 3 Basic Colors as finalColor
                         float3 finalColor =
@@ -435,8 +436,8 @@
                         float3 halfDirection = normalize(viewDirection + lightDirection); // has to be recalced here.
 
                         //v.2.0.5:
-                        _1st_ShadeColor_Step = saturate(_1st_ShadeColor_Step + _StepOffset);
-                        _2nd_ShadeColor_Step = saturate(_2nd_ShadeColor_Step + _StepOffset);
+                        float firstShadeColorStep = saturate(_1st_ShadeColor_Step + _StepOffset);
+                        float secondShadeColorStep = saturate(_2nd_ShadeColor_Step + _StepOffset);
                         //
                         //v.2.0.5: If Added lights is directional, set 0 as _LightIntensity
                         float _LightIntensity = lerp(0, (0.299*additionalLightColor.r + 0.587*additionalLightColor.g + 0.114*additionalLightColor.b), notDirectional);
@@ -473,8 +474,8 @@
 
 
                         //
-                        float Set_FinalShadowMask = saturate((1.0 + ((Set_ShadingGrade - (_1st_ShadeColor_Step - _1st_ShadeColor_Feather)) * (0.0 - 1.0)) / (_1st_ShadeColor_Step - (_1st_ShadeColor_Step - _1st_ShadeColor_Feather))));
-                        float Set_ShadeShadowMask = saturate((1.0 + ((Set_ShadingGrade - (_2nd_ShadeColor_Step - _2nd_ShadeColor_Feather)) * (0.0 - 1.0)) / (_2nd_ShadeColor_Step - (_2nd_ShadeColor_Step - _2nd_ShadeColor_Feather)))); // 1st and 2nd Shades Mask
+                        float Set_FinalShadowMask = saturate((1.0 + ((Set_ShadingGrade - (firstShadeColorStep - _1st_ShadeColor_Feather)) * (0.0 - 1.0)) / (firstShadeColorStep - (firstShadeColorStep - _1st_ShadeColor_Feather))));
+                        float Set_ShadeShadowMask = saturate((1.0 + ((Set_ShadingGrade - (secondShadeColorStep - _2nd_ShadeColor_Feather)) * (0.0 - 1.0)) / (secondShadeColorStep - (secondShadeColorStep - _2nd_ShadeColor_Feather)))); // 1st and 2nd Shades Mask
 
         //SGM
 

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
@@ -417,7 +417,6 @@
                     int iLight = loopCounter + MAINLIGHT_IS_MAINLIGHT;
                     if (iLight != i.mainLightID)
 #endif
-#endif
                     {
                         float notDirectional = 1.0f; //_WorldSpaceLightPos0.w of the legacy code.
                         UtsLight additionalLight = GetUrpMainUtsLight(0,0);


### PR DESCRIPTION
Hi, I was able to reproduce the issue and found that the problem was caused by an additional step increase in the for loop. Let's consider a scene with 4 lights and a material step value of 0.1. In this case, the step value for each light would be different: light0 would have a step value of 0.1, light1 would have a step value of 0.2, light2 would have a step value of 0.3, and light3 would have a step value of 0.4.

I suspect that the reason why this issue only occurs in forward+ is due to clustering. In normal forward rendering, lights are assigned per object, not per tile. Therefore, even though each light has a different step value, the pixel is ultimately overwritten by the last light calculation, which has the maximum step value.

However, in forward+, if each light has a different step value, then a pixel can be calculated with a different step value because the pixel will only be calculated by effective lights depending on the tile. For example, a certain pixel might be calculated by light0 with step 0.1, and it could skip the other three lights. However, the next pixel might be calculated by all four lights, even though these two pixels correspond to the same mesh. This is why the aliasing issue occurs.

To fix the issue, I modified the step so that it is not increased in the for loop. I am not certain if this is intended, so please let me know if this modification is difficult to merge.