### PR TITLE
Fix for the issue 325. https://github.com/Unity-Technologies/com.unit…

### DIFF
--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBody.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBody.hlsl
@@ -459,7 +459,9 @@
                 half fogFactor = ComputeFogFactor(positionCS.z);
 
                 OUTPUT_LIGHTMAP_UV(v.lightmapUV, unity_LightmapST, o.lightmapUV);
-#if UNITY_VERSION >= 202310
+#if UNITY_VERSION >= 202312
+                OUTPUT_SH4(positionWS, o.normalDir.xyz, GetWorldSpaceNormalizeViewDir(positionWS), o.vertexSH);
+#elif UNITY_VERSION >= 202310
                 OUTPUT_SH(positionWS, o.normalDir.xyz, GetWorldSpaceNormalizeViewDir(positionWS), o.vertexSH);
 #else
                 OUTPUT_SH(o.normalDir.xyz, o.vertexSH);


### PR DESCRIPTION
Fixed: URP Shader errors when using Unity 2023.1.3 or later. 
https://github.com/Unity-Technologies/com.unity.toonshader/issues/325