### PR TITLE
Fixed: Null reference exception when the HDRP tesselation shader is applied.

### DIFF
--- a/com.unity.toonshader/CHANGELOG.md
+++ b/com.unity.toonshader/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
-## [0.9.5-preview] - 2023-06-18
-TBD - not released yet.
+## [0.9.5-preview] - 2023-08-25
+### Fixed
+* A URP Shader error when using newer than 2023.1.3.
+* A Null Reference Exception error with HDRP tesslation shader.
 
 ## [0.9.4-preview] - 2023-05-01
 * Added a exlanation for URP line issue  into Kown Issues.

--- a/com.unity.toonshader/Editor/HDRP/HDRPToonGUI-Tessellation.cs
+++ b/com.unity.toonshader/Editor/HDRP/HDRPToonGUI-Tessellation.cs
@@ -99,7 +99,8 @@ namespace UnityEditor.Rendering.Toon
         void TessellationModePopup()
         {
             EditorGUI.showMixedValue = tessellationMode.hasMixedValue;
-            var mode = (TessellationMode)tessellationMode.floatValue;
+            TessellationMode mode = TessellationMode.None;
+            mode = (TessellationMode)tessellationMode?.floatValue;
 
             EditorGUI.BeginChangeCheck();
             mode = (TessellationMode)EditorGUILayout.Popup(TessellationStyles.tessellationModeText, (int)mode, TessellationStyles.tessellationModeNames);


### PR DESCRIPTION
Fixed: Null reference exception when the HDRP tesselation shader is applied.
https://github.com/Unity-Technologies/com.unity.toonshader/issues/321#issuecomment-1687218970