### PR TITLE
Fixed: incorrect version check when applying  OUTPUT_SH4() in UniversalToonBody.hlsl.

### DIFF
--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBody.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBody.hlsl
@@ -459,7 +459,7 @@
                 half fogFactor = ComputeFogFactor(positionCS.z);
 
                 OUTPUT_LIGHTMAP_UV(v.lightmapUV, unity_LightmapST, o.lightmapUV);
-#if UNITY_VERSION >= 202312
+#if UNITY_VERSION >= 202317
                 OUTPUT_SH4(positionWS, o.normalDir.xyz, GetWorldSpaceNormalizeViewDir(positionWS), o.vertexSH);
 #elif UNITY_VERSION >= 202310
                 OUTPUT_SH(positionWS, o.normalDir.xyz, GetWorldSpaceNormalizeViewDir(positionWS), o.vertexSH);


### PR DESCRIPTION
Fixed: incorrect version check when applying  OUTPUT_SH4() in UniversalToonBody.hlsl.
https://github.com/Unity-Technologies/com.unity.toonshader/issues/325