### PR TITLE
Add decal feature (URP only)

### DIFF
--- a/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToon.shader
+++ b/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToon.shader
@@ -1217,6 +1217,7 @@ Shader "Toon" {
             #pragma multi_compile _ _ADDITIONAL_LIGHT_SHADOWS
             #pragma multi_compile _ _SHADOWS_SOFT
             #pragma multi_compile _ _FORWARD_PLUS
+            #pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
 
             #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
             // -------------------------------------

--- a/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToonTessellation.shader
+++ b/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToonTessellation.shader
@@ -1278,7 +1278,8 @@ Shader "Toon(Tessellation)" {
             #pragma multi_compile _ _ADDITIONAL_LIGHT_SHADOWS
             #pragma multi_compile _ _SHADOWS_SOFT
             #pragma multi_compile _ _FORWARD_PLUS
-            
+            #pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
+
             #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
             // -------------------------------------
             // Unity defined keywords

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBody.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBody.hlsl
@@ -127,6 +127,29 @@
                 return EnvironmentBRDF(brdfData, indirectDiffuse, indirectSpecular, fresnelTerm);     
             }
 
+            void ApplyDecalToSurfaceDataUTS(float4 positionCS, inout float3 albedo, inout SurfaceData surfaceData, inout float3 normalWS)
+            {
+                #ifdef _SPECULAR_SETUP
+                    half metallic = 0;
+                    ApplyDecal(positionCS,
+                        albedo,
+                        surfaceData.specular,
+                        normalWS,
+                        metallic,
+                        surfaceData.occlusion,
+                        surfaceData.smoothness);
+                #else
+                    half3 specular = 0;
+                    ApplyDecal(positionCS,
+                        albedo,
+                        specular,
+                        normalWS,
+                        surfaceData.metallic,
+                        surfaceData.occlusion,
+                        surfaceData.smoothness);
+                #endif
+            }
+
             struct VertexInput {
                 float4 vertex : POSITION;
                 float3 normal : NORMAL;

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
@@ -84,6 +84,10 @@
                 half3 mainLightColor = GetLightColor(mainLight);
                 float4 _MainTex_var = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _MainTex));
 
+#ifdef _DBUFFER
+                ApplyDecalToSurfaceDataUTS(input.positionCS, _MainTex_var.rgb, surfaceData, normalDirection);
+#endif
+
 //v.2.0.4
 #if defined(_IS_CLIPPING_MODE) 
 //DoubleShadeWithFeather_Clipping

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
@@ -81,6 +81,10 @@
 
                 float4 _MainTex_var = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _MainTex));
 
+#ifdef _DBUFFER
+                ApplyDecalToSurfaceDataUTS(input.positionCS, _MainTex_var.rgb, surfaceData, normalDirection);
+#endif
+
 //v.2.0.4
 #ifdef _IS_TRANSCLIPPING_OFF
 //


### PR DESCRIPTION
# Summary
Add decal feature (URP only) https://github.com/Unity-Technologies/com.unity.toonshader/issues/271

# Details
- Add DBUFFER pragma to Universal Forward pass
- Add ApplyDecalToSurfaceDataUTS() to "UniversalToonBody.hlsl"
    -  [Built-in Function](https://github.com/Unity-Technologies/Graphics/blob/master/Packages/com.unity.render-pipelines.universal/ShaderLibrary/DBuffer.hlsl#L191-L211) adjusted to UTS
- Add decal calculation to frag()

> [!WARNING]
> "Normal Map Effectiveness" must be enabled to activate **decal normal**
>
> ![normal_map_effectiveness](https://github.com/Unity-Technologies/com.unity.toonshader/assets/117564304/69fa09d8-208d-4d4c-8826-a3c5b4f7224c)
> It may seem somewhat counterintuitive that this checkbox needs to be enabled even though Normal Map is not used.
> However, there is a concern that allowing decal normal to be enabled with this checkbox unchecked would make the code too complex.
> I'll leave it to you to decide if you want to keep it that way.
