### PR TITLE
Add light layers (URP only)

### DIFF
--- a/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToon.shader
+++ b/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToon.shader
@@ -1218,6 +1218,7 @@ Shader "Toon" {
             #pragma multi_compile _ _SHADOWS_SOFT
             #pragma multi_compile _ _FORWARD_PLUS
             #pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
+            #pragma multi_compile_fragment _ _LIGHT_LAYERS
 
             #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
             // -------------------------------------

--- a/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToonTessellation.shader
+++ b/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToonTessellation.shader
@@ -1279,6 +1279,7 @@ Shader "Toon(Tessellation)" {
             #pragma multi_compile _ _SHADOWS_SOFT
             #pragma multi_compile _ _FORWARD_PLUS
             #pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
+            #pragma multi_compile_fragment _ _LIGHT_LAYERS
 
             #pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
             // -------------------------------------


### PR DESCRIPTION
# Summary
Added light layers feature (URP only) https://github.com/Unity-Technologies/com.unity.toonshader/issues/337

# Environment
Windows 11
- 2022.3.5f1 URP Forward
    - It worked.
- 2022.3.5f1 URP Forward+
    - It worked.
- 2020.3.48.f1 URP Forward
    - It didn't work, but since the version does not support light layers to begin with, no problem. I have confirmed that there is no compile error.

# Details
- Added `_LIGHT_LAYERS` definition to UniversalForward pass
    - [Implementation in Universal Render Pipeline/Lit](https://github.com/Unity-Technologies/Graphics/blob/master/Packages/com.unity.render-pipelines.universal/Shaders/Lit.shader#L147)
- Added layerMask to strust UtsLight
    - [Implementation in Universal Render Pipeline/Lit](https://github.com/Unity-Technologies/Graphics/blob/master/Packages/com.unity.render-pipelines.universal/ShaderLibrary/RealtimeLights.hlsl#L18)
- Changed to branch on `_LIGHT_LAYERS` when calculating the lightColor in GetLightColor().
    - [Implementation in Universal Render Pipeline/Lit](https://github.com/Unity-Technologies/Graphics/blob/master/Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl#L297-L299)
- Changed frag() to return outRenderingLayers
    - [Implementation in Universal Render Pipeline/Lit](https://github.com/Unity-Technologies/Graphics/blob/master/Packages/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl#L210-L212)
- Versions of Unity that do not support light layers will not pass `#ifdef _LIGHT_LAYERS` and should not generate a compile error.

# Images
![light_layers01](https://github.com/Unity-Technologies/com.unity.toonshader/assets/117564304/39f7ba8e-d241-452d-b059-699cce3b6837)
