### PR TITLE
Support DOTS-Instancing (URP Only)

### DIFF
--- a/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToon.shader
+++ b/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToon.shader
@@ -1162,6 +1162,16 @@ Shader "Toon" {
             // Outline is implemented in UniversalToonOutline.hlsl.
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+        #if UNITY_VERSION >= 202230 // Requires Universal RP 14.0.7
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+        #else
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+        #endif
+
 #ifdef UNIVERSAL_PIPELINE_CORE_INCLUDED
             #include "../../UniversalRP/Shaders/UniversalToonInput.hlsl"
             #include "../../UniversalRP/Shaders/UniversalToonHead.hlsl"
@@ -1230,6 +1240,16 @@ Shader "Toon" {
             #pragma multi_compile _ DYNAMICLIGHTMAP_ON
             #pragma multi_compile_fog
 
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+            #pragma instancing_options renderinglayer
+        #if UNITY_VERSION >= 202230 // Requires Universal RP 14.0.7
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+        #else
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+        #endif
+
             #define _IS_PASS_FWDBASE
             // DoubleShadeWithFeather and ShadingGradeMap use different fragment shader.  
             #pragma shader_feature_local _ _SHADINGGRADEMAP
@@ -1273,6 +1293,14 @@ Shader "Toon" {
             #pragma prefer_hlslcc gles
             #pragma exclude_renderers d3d11_9x
 
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+        #if UNITY_VERSION >= 202230 // Requires Universal RP 14.0.7
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+        #else
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+        #endif
 
             #pragma shader_feature_local _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
 
@@ -1307,6 +1335,14 @@ Shader "Toon" {
             // Material Keywords
             #pragma shader_feature_local _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
 
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+        #if UNITY_VERSION >= 202230 // Requires Universal RP 14.0.7
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+        #else
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+        #endif
 
 
             #include "../../UniversalRP/Shaders/UniversalToonInput.hlsl"
@@ -1340,6 +1376,14 @@ Shader "Toon" {
             #pragma shader_feature_local _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
 
 
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+        #if UNITY_VERSION >= 202230 // Requires Universal RP 14.0.7
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+        #else
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+        #endif
 
             #include "../../UniversalRP/Shaders/UniversalToonInput.hlsl"
             #include "Packages/com.unity.render-pipelines.universal/Shaders/DepthNormalsPass.hlsl"

--- a/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToonTessellation.shader
+++ b/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToonTessellation.shader
@@ -1223,6 +1223,16 @@ Shader "Toon(Tessellation)" {
             // Outline is implemented in UniversalToonOutline.hlsl.
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+        #if UNITY_VERSION >= 202230 // Requires Universal RP 14.0.7
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+        #else
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+        #endif
+
 #ifdef UNIVERSAL_PIPELINE_CORE_INCLUDED
             #include "../../UniversalRP/Shaders/UniversalToonInput.hlsl"
             #include "../../UniversalRP/Shaders/UniversalToonHead.hlsl"
@@ -1291,6 +1301,16 @@ Shader "Toon(Tessellation)" {
             #pragma multi_compile _ DYNAMICLIGHTMAP_ON
             #pragma multi_compile_fog
 
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+            #pragma instancing_options renderinglayer
+        #if UNITY_VERSION >= 202230 // Requires Universal RP 14.0.7
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+        #else
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+        #endif
+
             #define _IS_PASS_FWDBASE
             // DoubleShadeWithFeather and ShadingGradeMap use different fragment shader.  
             #pragma shader_feature_local _ _SHADINGGRADEMAP
@@ -1334,6 +1354,13 @@ Shader "Toon(Tessellation)" {
             #pragma exclude_renderers d3d11_9x
 
             // -------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+        #if UNITY_VERSION >= 202230 // Requires Universal RP 14.0.7
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+        #else
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+        #endif
 
             #pragma shader_feature_local _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
 
@@ -1367,6 +1394,14 @@ Shader "Toon(Tessellation)" {
             // Material Keywords
             #pragma shader_feature_local _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
 
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+        #if UNITY_VERSION >= 202230 // Requires Universal RP 14.0.7
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+        #else
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+        #endif
 
 
             #include "../../UniversalRP/Shaders/UniversalToonInput.hlsl"
@@ -1402,6 +1437,14 @@ Shader "Toon(Tessellation)" {
             #pragma shader_feature_local _PARALLAXMAP
             #pragma shader_feature_local _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
 
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+        #if UNITY_VERSION >= 202230 // Requires Universal RP 14.0.7
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+        #else
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+        #endif
 
             #include "../../UniversalRP/Shaders/UniversalToonInput.hlsl"
             #include "Packages/com.unity.render-pipelines.universal/Shaders/DepthNormalsPass.hlsl"

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBody.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBody.hlsl
@@ -492,9 +492,9 @@
                 o.uv1 = v.texcoord1;
 #endif
                 o.normalDir = UnityObjectToWorldNormal(v.normal);
-                o.tangentDir = normalize( mul( unity_ObjectToWorld, float4( v.tangent.xyz, 0.0 ) ).xyz );
+                o.tangentDir = normalize( mul( GetObjectToWorldMatrix(), float4( v.tangent.xyz, 0.0 ) ).xyz );
                 o.bitangentDir = normalize(cross(o.normalDir, o.tangentDir) * v.tangent.w);
-                o.posWorld = mul(unity_ObjectToWorld, v.vertex);
+                o.posWorld = mul(GetObjectToWorldMatrix(), v.vertex);
 
                 o.pos = UnityObjectToClipPos( v.vertex );
                 //v.2.0.7 Detection of the inside the mirror (right or left-handed) o.mirrorFlag = -1 then "inside the mirror".

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
@@ -139,7 +139,7 @@
                 float3 defaultLightDirection = normalize(UNITY_MATRIX_V[2].xyz + UNITY_MATRIX_V[1].xyz);
                 //v.2.0.5
                 float3 defaultLightColor = saturate(max(half3(0.05,0.05,0.05)*_Unlit_Intensity,max(ShadeSH9(half4(0.0, 0.0, 0.0, 1.0)),ShadeSH9(half4(0.0, -1.0, 0.0, 1.0)).rgb)*_Unlit_Intensity));
-                float3 customLightDirection = normalize(mul( unity_ObjectToWorld, float4(((float3(1.0,0.0,0.0)*_Offset_X_Axis_BLD*10)+(float3(0.0,1.0,0.0)*_Offset_Y_Axis_BLD*10)+(float3(0.0,0.0,-1.0)*lerp(-1.0,1.0,_Inverse_Z_Axis_BLD))),0)).xyz);
+                float3 customLightDirection = normalize(mul( GetObjectToWorldMatrix(), float4(((float3(1.0,0.0,0.0)*_Offset_X_Axis_BLD*10)+(float3(0.0,1.0,0.0)*_Offset_Y_Axis_BLD*10)+(float3(0.0,0.0,-1.0)*lerp(-1.0,1.0,_Inverse_Z_Axis_BLD))),0)).xyz);
                 float3 lightDirection = normalize(lerp(defaultLightDirection, mainLight.direction.xyz,any(mainLight.direction.xyz)));
                 lightDirection = lerp(lightDirection, customLightDirection, _Is_BLD);
                 //v.2.0.5: 

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
@@ -127,7 +127,7 @@
                 float3 defaultLightDirection = normalize(UNITY_MATRIX_V[2].xyz + UNITY_MATRIX_V[1].xyz);
                 //v.2.0.5
                 float3 defaultLightColor = saturate(max(half3(0.05,0.05,0.05)*_Unlit_Intensity,max(ShadeSH9(half4(0.0, 0.0, 0.0, 1.0)),ShadeSH9(half4(0.0, -1.0, 0.0, 1.0)).rgb)*_Unlit_Intensity));
-                float3 customLightDirection = normalize(mul( unity_ObjectToWorld, float4(((float3(1.0,0.0,0.0)*_Offset_X_Axis_BLD*10)+(float3(0.0,1.0,0.0)*_Offset_Y_Axis_BLD*10)+(float3(0.0,0.0,-1.0)*lerp(-1.0,1.0,_Inverse_Z_Axis_BLD))),0)).xyz);
+                float3 customLightDirection = normalize(mul( GetObjectToWorldMatrix(), float4(((float3(1.0,0.0,0.0)*_Offset_X_Axis_BLD*10)+(float3(0.0,1.0,0.0)*_Offset_Y_Axis_BLD*10)+(float3(0.0,0.0,-1.0)*lerp(-1.0,1.0,_Inverse_Z_Axis_BLD))),0)).xyz);
                 float3 lightDirection = normalize(lerp(defaultLightDirection, mainLight.direction.xyz,any(mainLight.direction.xyz)));
                 lightDirection = lerp(lightDirection, customLightDirection, _Is_BLD);
                 //v.2.0.5: 

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonHead.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonHead.hlsl
@@ -150,7 +150,7 @@ inline float4 UnityObjectToClipPosInstanced(in float3 pos)
 {
     //    return mul(UNITY_MATRIX_VP, mul(unity_ObjectToWorldArray[unity_InstanceID], float4(pos, 1.0)));
           // todo. right?
-    return mul(UNITY_MATRIX_VP, mul(unity_ObjectToWorld, float4(pos, 1.0)));
+    return mul(UNITY_MATRIX_VP, mul(GetObjectToWorldMatrix(), float4(pos, 1.0)));
 }
 inline float4 UnityObjectToClipPosInstanced(float4 pos)
 {
@@ -164,7 +164,7 @@ inline float3 UnityObjectToWorldNormal(in float3 norm)
     return UnityObjectToWorldDir(norm);
 #else
     // mul(IT_M, norm) => mul(norm, I_M) => {dot(norm, I_M.col0), dot(norm, I_M.col1), dot(norm, I_M.col2)}
-    return normalize(mul(norm, (float3x3)unity_WorldToObject));
+    return normalize(mul(norm, (float3x3)GetWorldToObjectMatrix()));
 #endif
 }
 // normal should be normalized, w=1.0

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonOutline.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonOutline.hlsl
@@ -29,12 +29,12 @@
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
                 o.uv0 = v.texcoord0;
-                float4 objPos = mul ( unity_ObjectToWorld, float4(0,0,0,1) );
+                float4 objPos = mul (GetObjectToWorldMatrix(), float4(0,0,0,1) );
                 float2 Set_UV0 = o.uv0;
                 float4 _Outline_Sampler_var = tex2Dlod(_Outline_Sampler,float4(TRANSFORM_TEX(Set_UV0, _Outline_Sampler),0.0,0));
                 //v.2.0.4.3 baked Normal Texture for Outline
                 o.normalDir = UnityObjectToWorldNormal(v.normal);
-                o.tangentDir = normalize( mul( unity_ObjectToWorld, float4( v.tangent.xyz, 0.0 ) ).xyz );
+                o.tangentDir = normalize( mul( GetObjectToWorldMatrix(), float4( v.tangent.xyz, 0.0 ) ).xyz );
                 o.bitangentDir = normalize(cross(o.normalDir, o.tangentDir) * v.tangent.w);
                 float3x3 tangentTransform = float3x3( o.tangentDir, o.bitangentDir, o.normalDir);
                 //UnpackNormal() can't be used, and so as follows. Do not specify a bump for the texture to be used.
@@ -73,7 +73,7 @@
                     return float4(1.0f, 1.0f, 1.0f, 1.0f);  // but nothing should be drawn except Z value as colormask is set to 0
                 }
                 _Color = _BaseColor;
-                float4 objPos = mul ( unity_ObjectToWorld, float4(0,0,0,1) );
+                float4 objPos = mul ( GetObjectToWorldMatrix(), float4(0,0,0,1) );
                 //v.2.0.9
                 float3 envLightSource_GradientEquator = unity_AmbientEquator.rgb >0.05 ? unity_AmbientEquator.rgb : half3(0.05,0.05,0.05);
                 float3 envLightSource_SkyboxIntensity = max(ShadeSH9(half4(0.0,0.0,0.0,1.0)),ShadeSH9(half4(0.0,-1.0,0.0,1.0))).rgb;


### PR DESCRIPTION
# Summary
Support DOTS-Instancing (URP Only)
- https://github.com/Unity-Technologies/com.unity.toonshader/issues/268

# Environment
Windows 11
- [x] 2022.3.5f1 URP Forward
    - It worked.
- [x] 2022.3.5f1 URP Forward+
    - It worked.
- [ ] 2020.3.48.f1 URP Forward
    - It didn't work. This is due to a compile error in **Entities(Preview)** and is not directly related to UTS. If you want to use DOTS Instancing, you should not use the **Preview** version of Package.
    - If you do not install Entities(Preview), no error occurs and you can use the shaders as usual

# Details
- Added definitions required for GPU Instancing and DOTS Instancing
    - Since **URP14.0.7**, the required definitions have become a bit more complex, and it seems that the hlsl file has to be included. 
    - In addition to that, URP14.0.7 is supported from **Unity2022.2.14f1**, but Unity2022.2.14f1 seems to be 20222**9** in UNITY_VERSION. So we decided to support it from **202230**.
- **unity_ObjectToWorld** and **unity_WorldToObject** have been changed to use render-pipelines core library
    - This is because DOTS Instancing no longer uses unity_ObjectToWorld, etc.
    - The core library seems to be automatically rewritten when using DOTS Instancing

![dots-instancing01](https://github.com/Unity-Technologies/com.unity.toonshader/assets/117564304/61cfc607-67e1-4812-9f02-8855b2d39bad)
