### PR TITLE
Fixed Undo bug in custom inspector

### DIFF
--- a/com.unity.toonshader/Editor/UTS3GUI.cs
+++ b/com.unity.toonshader/Editor/UTS3GUI.cs
@@ -1036,11 +1036,11 @@ namespace UnityEditor.Rendering.Toon
             EditorGUIUtility.fieldWidth = 0;
             if (m_FirstTimeApply)
             {
-                FindProperties(props);
                 OnOpenGUI(material, materialEditor, props);
                 m_FirstTimeApply = false;
             }
 
+            FindProperties(props);
             UpdateVersionInMaterial(material);
 
             m_autoRenderQueue = MaterialGetInt(material,ShaderPropAutoRenderQueue);


### PR DESCRIPTION
# Summary
Fixed a bug that material properties in the Custom Inspector were not updated on Undo.
- https://github.com/Unity-Technologies/com.unity.toonshader/issues/298#issuecomment-2009562470

# Details
- This bug is due to the fact that material properties are updated only once at the beginning. So we have changed it to update every time.
- Some properties may work correctly Undo without such modifications, but this is due to differences in the implementation of the custom inspector
- The custom inspector of URP built-in shaders seems to take the same approach to this PR
    - https://github.com/Unity-Technologies/Graphics/blob/master/Packages/com.unity.render-pipelines.universal/Editor/ShaderGUI/BaseShaderGUI.cs#L483
- The load caused by this modification was not a problem on my PC. It's running comfortably.