### PR TITLE
Task/clipping mask sampler

### DIFF
--- a/.yamato/win_dx11-urp-stereo-2020.3.yml
+++ b/.yamato/win_dx11-urp-stereo-2020.3.yml
@@ -6,7 +6,7 @@ test_projects:
 unity_versions:
   - name: 2020.3
   - name: 2021.3
-  - name: 2022.3
+#  - name: 2022.3
 ---
 {% for test_project in test_projects %}
 {% for unity_version in unity_versions %}

--- a/com.unity.toonshader/Editor/UTS3GUI.cs
+++ b/com.unity.toonshader/Editor/UTS3GUI.cs
@@ -1036,11 +1036,11 @@ namespace UnityEditor.Rendering.Toon
             EditorGUIUtility.fieldWidth = 0;
             if (m_FirstTimeApply)
             {
-                FindProperties(props);
                 OnOpenGUI(material, materialEditor, props);
                 m_FirstTimeApply = false;
             }
 
+            FindProperties(props);
             UpdateVersionInMaterial(material);
 
             m_autoRenderQueue = MaterialGetInt(material,ShaderPropAutoRenderQueue);

--- a/com.unity.toonshader/Runtime/HDRP/Shaders/DoubleShadeWithFeatherMainLight.hlsl
+++ b/com.unity.toonshader/Runtime/HDRP/Shaders/DoubleShadeWithFeatherMainLight.hlsl
@@ -43,12 +43,12 @@ float3 UTS_MainLight(LightLoopContext lightLoopContext, FragInputs input, float3
     //v.2.0.4
 #if defined(_IS_CLIPPING_MODE) 
 //DoubleShadeWithFeather_Clipping
-    float4 _ClippingMask_var = SAMPLE_TEXTURE2D(_ClippingMask, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _ClippingMask));
+    float4 _ClippingMask_var = SAMPLE_TEXTURE2D(_ClippingMask, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _MainTex));
     float Set_Clipping = saturate((lerp(_ClippingMask_var.r, (1.0 - _ClippingMask_var.r), _Inverse_Clipping) + _Clipping_Level));
     clip(Set_Clipping - 0.5);
 #elif defined(_IS_CLIPPING_TRANSMODE) || defined(_IS_TRANSCLIPPING_ON)
 //DoubleShadeWithFeather_TransClipping
-    float4 _ClippingMask_var = SAMPLE_TEXTURE2D(_ClippingMask, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _ClippingMask));
+    float4 _ClippingMask_var = SAMPLE_TEXTURE2D(_ClippingMask, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _MainTex));
     float Set_MainTexAlpha = _MainTex_var.a;
     float _IsBaseMapAlphaAsClippingMask_var = lerp(_ClippingMask_var.r, Set_MainTexAlpha, _IsBaseMapAlphaAsClippingMask);
     float _Inverse_Clipping_var = lerp(_IsBaseMapAlphaAsClippingMask_var, (1.0 - _IsBaseMapAlphaAsClippingMask_var), _Inverse_Clipping);

--- a/com.unity.toonshader/Runtime/HDRP/Shaders/HDRPToonOutline.hlsl
+++ b/com.unity.toonshader/Runtime/HDRP/Shaders/HDRPToonOutline.hlsl
@@ -183,7 +183,7 @@ void Frag(PackedVaryingsToPS packedInput,
 
 
 #elif _IS_OUTLINE_CLIPPING_YES
-    float4 _ClippingMask_var = SAMPLE_TEXTURE2D(_ClippingMask, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _ClippingMask));
+    float4 _ClippingMask_var = SAMPLE_TEXTURE2D(_ClippingMask, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _MainTex));
     float Set_MainTexAlpha = _MainTex_var.a;
     float _IsBaseMapAlphaAsClippingMask_var = lerp( _ClippingMask_var.r, Set_MainTexAlpha, _IsBaseMapAlphaAsClippingMask );
     float _Inverse_Clipping_var = lerp( _IsBaseMapAlphaAsClippingMask_var, (1.0 - _IsBaseMapAlphaAsClippingMask_var), _Inverse_Clipping );

--- a/com.unity.toonshader/Runtime/HDRP/Shaders/ShadingGrademapMainLight.hlsl
+++ b/com.unity.toonshader/Runtime/HDRP/Shaders/ShadingGrademapMainLight.hlsl
@@ -54,7 +54,7 @@ float3 UTS_MainLightShadingGrademap(LightLoopContext lightLoopContext, FragInput
 #ifdef _IS_TRANSCLIPPING_OFF
 //
 #elif _IS_TRANSCLIPPING_ON
-    float4 _ClippingMask_var = SAMPLE_TEXTURE2D(_ClippingMask, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _ClippingMask));
+    float4 _ClippingMask_var = SAMPLE_TEXTURE2D(_ClippingMask, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _MainTex));
     float Set_MainTexAlpha = _MainTex_var.a;
     float _IsBaseMapAlphaAsClippingMask_var = lerp(_ClippingMask_var.r, Set_MainTexAlpha, _IsBaseMapAlphaAsClippingMask);
     float _Inverse_Clipping_var = lerp(_IsBaseMapAlphaAsClippingMask_var, (1.0 - _IsBaseMapAlphaAsClippingMask_var), _Inverse_Clipping);

--- a/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_DoubleShadeWithFeather.cginc
+++ b/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_DoubleShadeWithFeather.cginc
@@ -104,13 +104,13 @@ struct VertexOutput {
 //v.2.0.4
 #ifdef _IS_CLIPPING_MODE
 //DoubleShadeWithFeather_Clipping
-                float4 _ClippingMask_var = tex2D(_ClippingMask, TRANSFORM_TEX(Set_UV0, _ClippingMask));
+                float4 _ClippingMask_var = tex2D(_ClippingMask, TRANSFORM_TEX(Set_UV0, _MainTex));
                 float Set_Clipping = saturate((lerp( _ClippingMask_var.r, (1.0 - _ClippingMask_var.r), _Inverse_Clipping )+_Clipping_Level));
                 clip(Set_Clipping - 0.5);
 #elif _IS_CLIPPING_TRANSMODE
 //DoubleShadeWithFeather_TransClipping
 
-                float4 _ClippingMask_var = tex2D(_ClippingMask, TRANSFORM_TEX(Set_UV0, _ClippingMask));
+                float4 _ClippingMask_var = tex2D(_ClippingMask, TRANSFORM_TEX(Set_UV0, _MainTex));
                 float Set_MainTexAlpha = _MainTex_var.a;
                 float _IsBaseMapAlphaAsClippingMask_var = lerp( _ClippingMask_var.r, Set_MainTexAlpha, _IsBaseMapAlphaAsClippingMask );
                 float _Inverse_Clipping_var = lerp( _IsBaseMapAlphaAsClippingMask_var, (1.0 - _IsBaseMapAlphaAsClippingMask_var), _Inverse_Clipping );

--- a/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_ShadingGradeMap.cginc
+++ b/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_ShadingGradeMap.cginc
@@ -134,7 +134,7 @@ struct VertexOutput {
 #elif _IS_TRANSCLIPPING_ON
 
 
-                float4 _ClippingMask_var = tex2D(_ClippingMask,TRANSFORM_TEX(Set_UV0, _ClippingMask));
+                float4 _ClippingMask_var = tex2D(_ClippingMask,TRANSFORM_TEX(Set_UV0, _MainTex));
                 float Set_MainTexAlpha = _MainTex_var.a;
                 float _IsBaseMapAlphaAsClippingMask_var = lerp( _ClippingMask_var.r, Set_MainTexAlpha, _IsBaseMapAlphaAsClippingMask );
                 float _Inverse_Clipping_var = lerp( _IsBaseMapAlphaAsClippingMask_var, (1.0 - _IsBaseMapAlphaAsClippingMask_var), _Inverse_Clipping );

--- a/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_ShadowCaster.cginc
+++ b/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_ShadowCaster.cginc
@@ -57,14 +57,14 @@
 #ifdef _IS_CLIPPING_MODE
 //_Clipping
                 float2 Set_UV0 = i.uv0;
-                float4 _ClippingMask_var = tex2D(_ClippingMask,TRANSFORM_TEX(Set_UV0, _ClippingMask));
+                float4 _ClippingMask_var = tex2D(_ClippingMask,TRANSFORM_TEX(Set_UV0, _MainTex));
                 float Set_Clipping = saturate((lerp( _ClippingMask_var.r, (1.0 - _ClippingMask_var.r), _Inverse_Clipping )+_Clipping_Level));
                 clip(Set_Clipping - 0.5);
 #elif _IS_CLIPPING_TRANSMODE
 //_TransClipping
                 float2 Set_UV0 = i.uv0;
 
-                float4 _ClippingMask_var = tex2D(_ClippingMask, TRANSFORM_TEX(Set_UV0, _ClippingMask));
+                float4 _ClippingMask_var = tex2D(_ClippingMask, TRANSFORM_TEX(Set_UV0, _MainTex));
                 float4 _MainTex_var = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _MainTex));
 
                 float Set_MainTexAlpha = _MainTex_var.a;

--- a/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_ShadowCaster_Tess.cginc
+++ b/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_ShadowCaster_Tess.cginc
@@ -78,13 +78,13 @@
 #ifdef _IS_CLIPPING_MODE
 //_Clipping
                 float2 Set_UV0 = i.uv0;
-                float4 _ClippingMask_var = tex2D(_ClippingMask,TRANSFORM_TEX(Set_UV0, _ClippingMask));
+                float4 _ClippingMask_var = tex2D(_ClippingMask,TRANSFORM_TEX(Set_UV0, _MainTex));
                 float Set_Clipping = saturate((lerp( _ClippingMask_var.r, (1.0 - _ClippingMask_var.r), _Inverse_Clipping )+_Clipping_Level));
                 clip(Set_Clipping - 0.5);
 #elif _IS_CLIPPING_TRANSMODE
 //_TransClipping
                 float2 Set_UV0 = i.uv0;
-                float4 _ClippingMask_var = tex2D(_ClippingMask,TRANSFORM_TEX(Set_UV0, _ClippingMask));
+                float4 _ClippingMask_var = tex2D(_ClippingMask,TRANSFORM_TEX(Set_UV0, _MainTex));
                 float4 _MainTex_var = SAMPLE_TEXTURE2D(_MainTex,sampler_MainTex,TRANSFORM_TEX(Set_UV0, _MainTex));
                 float Set_MainTexAlpha = _MainTex_var.a;
                 float _IsBaseMapAlphaAsClippingMask_var = lerp( _ClippingMask_var.r, Set_MainTexAlpha, _IsBaseMapAlphaAsClippingMask );

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
@@ -108,13 +108,13 @@
 //v.2.0.4
 #if defined(_IS_CLIPPING_MODE) 
 //DoubleShadeWithFeather_Clipping
-                float4 _ClippingMask_var = SAMPLE_TEXTURE2D(_ClippingMask, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _ClippingMask));
+                float4 _ClippingMask_var = SAMPLE_TEXTURE2D(_ClippingMask, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _MainTex));
                 float Set_Clipping = saturate((lerp( _ClippingMask_var.r, (1.0 - _ClippingMask_var.r), _Inverse_Clipping )+_Clipping_Level));
                 clip(Set_Clipping - 0.5);
 #elif defined(_IS_CLIPPING_TRANSMODE) || defined(_IS_TRANSCLIPPING_ON)
 //DoubleShadeWithFeather_TransClipping
 
-                float4 _ClippingMask_var = SAMPLE_TEXTURE2D(_ClippingMask, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _ClippingMask));
+                float4 _ClippingMask_var = SAMPLE_TEXTURE2D(_ClippingMask, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _MainTex));
                 float Set_MainTexAlpha = _MainTex_var.a;
                 float _IsBaseMapAlphaAsClippingMask_var = lerp( _ClippingMask_var.r, Set_MainTexAlpha, _IsBaseMapAlphaAsClippingMask );
                 float _Inverse_Clipping_var = lerp( _IsBaseMapAlphaAsClippingMask_var, (1.0 - _IsBaseMapAlphaAsClippingMask_var), _Inverse_Clipping );

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
@@ -106,7 +106,7 @@
 //
 #elif _IS_TRANSCLIPPING_ON
 
-                float4 _ClippingMask_var = SAMPLE_TEXTURE2D(_ClippingMask, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _ClippingMask));
+                float4 _ClippingMask_var = SAMPLE_TEXTURE2D(_ClippingMask, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _MainTex));
                 float Set_MainTexAlpha = _MainTex_var.a;
                 float _IsBaseMapAlphaAsClippingMask_var = lerp( _ClippingMask_var.r, Set_MainTexAlpha, _IsBaseMapAlphaAsClippingMask );
                 float _Inverse_Clipping_var = lerp( _IsBaseMapAlphaAsClippingMask_var, (1.0 - _IsBaseMapAlphaAsClippingMask_var), _Inverse_Clipping );

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonOutline.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonOutline.hlsl
@@ -94,7 +94,7 @@
                 float3 Set_Outline_Color = lerp(_Is_BlendBaseColor_var, _OutlineTex_var.rgb*_Outline_Color.rgb*lightColor, _Is_OutlineTex );
                 return float4(Set_Outline_Color,1.0);
 #elif _IS_OUTLINE_CLIPPING_YES
-                float4 _ClippingMask_var = SAMPLE_TEXTURE2D(_ClippingMask, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _ClippingMask));
+                float4 _ClippingMask_var = SAMPLE_TEXTURE2D(_ClippingMask, sampler_MainTex, TRANSFORM_TEX(Set_UV0, _MainTex));
                 float Set_MainTexAlpha = _MainTex_var.a;
                 float _IsBaseMapAlphaAsClippingMask_var = lerp( _ClippingMask_var.r, Set_MainTexAlpha, _IsBaseMapAlphaAsClippingMask );
                 float _Inverse_Clipping_var = lerp( _IsBaseMapAlphaAsClippingMask_var, (1.0 - _IsBaseMapAlphaAsClippingMask_var), _Inverse_Clipping );


### PR DESCRIPTION
Fixed: an issue that tile/offset value Undo/Redo won't be affected to the screen until selected material is changed.