### PR TITLE
Fixed a bug where plain could not be selected

### DIFF
--- a/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToon.shader
+++ b/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToon.shader
@@ -1426,41 +1426,6 @@ Shader "Toon" {
         Tags {
             "RenderType"="Opaque"
         }
-        Pass {
-            Name "Outline"
-            Tags {
-                "LightMode"="ForwardBase"
-            }
-            Cull[_SRPDefaultUnlitColMode]
-            ColorMask[_SPRDefaultUnlitColorMask]
-            Blend SrcAlpha OneMinusSrcAlpha
-            Stencil
-            {
-                Ref[_StencilNo]
-                Comp[_StencilComp]
-                Pass[_StencilOpPass]
-                Fail[_StencilOpFail]
-
-            }
-            CGPROGRAM
-            #pragma vertex vert
-            #pragma fragment frag
-            #include "UnityCG.cginc"
-            //#pragma fragmentoption ARB_precision_hint_fastest
-            //#pragma multi_compile_shadowcaster
-            //#pragma multi_compile_fog
-            #pragma only_renderers d3d9 d3d11 glcore gles gles3 playstation xboxone xboxseries vulkan metal switch
-
-            #pragma target 3.0
-            //V.2.0.4
-            #pragma multi_compile _IS_OUTLINE_CLIPPING_NO 
-            #pragma multi_compile _OUTLINE_NML _OUTLINE_POS
-            // Unity Toon Shader 0.5.0
-            #pragma multi_compile _ _DISABLE_OUTLINE
-            //The outline process goes to UTS_Outline.cginc.
-            #include "../../Legacy/Shaders/UCTS_Outline.cginc"
-            ENDCG
-        }
 //ToonCoreStart
         Pass {
             Name "FORWARD"
@@ -1515,6 +1480,41 @@ Shader "Toon" {
 
 #endif //#if defined(_SHADINGGRADEMAP)
 
+            ENDCG
+        }
+        Pass {
+            Name "Outline"
+            Tags {
+                "LightMode"="ForwardBase"
+            }
+            Cull[_SRPDefaultUnlitColMode]
+            ColorMask[_SPRDefaultUnlitColorMask]
+            Blend SrcAlpha OneMinusSrcAlpha
+            Stencil
+            {
+                Ref[_StencilNo]
+                Comp[_StencilComp]
+                Pass[_StencilOpPass]
+                Fail[_StencilOpFail]
+
+            }
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+            //#pragma fragmentoption ARB_precision_hint_fastest
+            //#pragma multi_compile_shadowcaster
+            //#pragma multi_compile_fog
+            #pragma only_renderers d3d9 d3d11 glcore gles gles3 playstation xboxone xboxseries vulkan metal switch
+
+            #pragma target 3.0
+            //V.2.0.4
+            #pragma multi_compile _IS_OUTLINE_CLIPPING_NO
+            #pragma multi_compile _OUTLINE_NML _OUTLINE_POS
+            // Unity Toon Shader 0.5.0
+            #pragma multi_compile _ _DISABLE_OUTLINE
+            //The outline process goes to UTS_Outline.cginc.
+            #include "../../Legacy/Shaders/UCTS_Outline.cginc"
             ENDCG
         }
         Pass {

--- a/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToon.shader
+++ b/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToon.shader
@@ -1139,52 +1139,6 @@ Shader "Toon" {
             "RenderType"="Opaque"
             "RenderPipeline" = "UniversalPipeline"
         }
-        Pass {
-            Name "Outline"
-            Tags {
-                "LightMode" = "SRPDefaultUnlit"
-            }
-            Cull [_SRPDefaultUnlitColMode]
-            ColorMask [_SPRDefaultUnlitColorMask]
-            Blend SrcAlpha OneMinusSrcAlpha
-            Stencil
-            {
-                Ref[_StencilNo]
-                Comp[_StencilComp]
-                Pass[_StencilOpPass]
-                Fail[_StencilOpFail]
-
-            }
-
-            HLSLPROGRAM
-            #pragma target 2.0
-            #pragma vertex vert
-            #pragma fragment frag
-
-
-            //V.2.0.4
-            #pragma multi_compile _IS_OUTLINE_CLIPPING_NO _IS_OUTLINE_CLIPPING_YES
-            #pragma multi_compile _OUTLINE_NML _OUTLINE_POS
-            // Outline is implemented in UniversalToonOutline.hlsl.
-            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
-
-            //--------------------------------------
-            // GPU Instancing
-            #pragma multi_compile_instancing
-        #if UNITY_VERSION >= 202230 // Requires Universal RP 14.0.7
-            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
-        #else
-            #pragma multi_compile _ DOTS_INSTANCING_ON
-        #endif
-
-#ifdef UNIVERSAL_PIPELINE_CORE_INCLUDED
-            #include "../../UniversalRP/Shaders/UniversalToonInput.hlsl"
-            #include "../../UniversalRP/Shaders/UniversalToonHead.hlsl"
-            #include "../../UniversalRP/Shaders/UniversalToonOutline.hlsl"
-#endif
-            ENDHLSL
-        }
 
 //ToonCoreStart
         Pass {
@@ -1298,6 +1252,53 @@ Shader "Toon" {
 #endif
             ENDHLSL
             
+        }
+
+        Pass {
+            Name "Outline"
+            Tags {
+                "LightMode" = "SRPDefaultUnlit"
+            }
+            Cull [_SRPDefaultUnlitColMode]
+            ColorMask [_SPRDefaultUnlitColorMask]
+            Blend SrcAlpha OneMinusSrcAlpha
+            Stencil
+            {
+                Ref[_StencilNo]
+                Comp[_StencilComp]
+                Pass[_StencilOpPass]
+                Fail[_StencilOpFail]
+
+            }
+
+            HLSLPROGRAM
+            #pragma target 2.0
+            #pragma vertex vert
+            #pragma fragment frag
+
+
+            //V.2.0.4
+            #pragma multi_compile _IS_OUTLINE_CLIPPING_NO _IS_OUTLINE_CLIPPING_YES
+            #pragma multi_compile _OUTLINE_NML _OUTLINE_POS
+            // Outline is implemented in UniversalToonOutline.hlsl.
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+        #if UNITY_VERSION >= 202230 // Requires Universal RP 14.0.7
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+        #else
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+        #endif
+
+#ifdef UNIVERSAL_PIPELINE_CORE_INCLUDED
+            #include "../../UniversalRP/Shaders/UniversalToonInput.hlsl"
+            #include "../../UniversalRP/Shaders/UniversalToonHead.hlsl"
+            #include "../../UniversalRP/Shaders/UniversalToonOutline.hlsl"
+#endif
+            ENDHLSL
         }
 
         Pass

--- a/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToonTessellation.shader
+++ b/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToonTessellation.shader
@@ -1480,47 +1480,6 @@ Shader "Toon(Tessellation)" {
         Tags {
             "RenderType"="Opaque"
         }
-        Pass {
-            Name "Outline"
-            Tags {
-                "LightMode"="ForwardBase"
-            }
-            Cull[_SRPDefaultUnlitColMode]
-            ColorMask[_SPRDefaultUnlitColorMask]
-            Blend SrcAlpha OneMinusSrcAlpha
-            Stencil
-            {
-                Ref[_StencilNo]
-                Comp[_StencilComp]
-                Pass[_StencilOpPass]
-                Fail[_StencilOpFail]
-
-            }
-            CGPROGRAM
-            #define TESSELLATION_ON
-            #pragma target 5.0
-            #pragma vertex tess_VertexInput
-            #pragma hull hs_VertexInput
-            #pragma domain ds_surf
-            #pragma fragment frag
-	    #ifdef TESSELLATION_ON
-            #include "../../Legacy/Shaders/UCTS_Tess.cginc"
-            #endif
-            #include "UnityCG.cginc"
-            //#pragma fragmentoption ARB_precision_hint_fastest
-            //#pragma multi_compile_shadowcaster
-            //#pragma multi_compile_fog
-            #pragma only_renderers d3d9 d3d11 glcore gles gles3 playstation xboxone xboxseries vulkan metal switch
-
-	    //V.2.0.4
-            #pragma multi_compile _IS_OUTLINE_CLIPPING_NO 
-            #pragma multi_compile _OUTLINE_NML _OUTLINE_POS
-            // Unity Toon Shader 0.5.0
-            #pragma multi_compile _ _DISABLE_OUTLINE
-            //The outline process goes to UTS_Outline.cginc.
-            #include "../../Legacy/Shaders/UCTS_Outline_tess.cginc"
-            ENDCG
-        }
 //ToonCoreStart
         Pass {
             Name "FORWARD"
@@ -1582,6 +1541,47 @@ Shader "Toon(Tessellation)" {
 
 #endif //#if defined(_SHADINGGRADEMAP)
 
+            ENDCG
+        }
+        Pass {
+            Name "Outline"
+            Tags {
+                "LightMode"="ForwardBase"
+            }
+            Cull[_SRPDefaultUnlitColMode]
+            ColorMask[_SPRDefaultUnlitColorMask]
+            Blend SrcAlpha OneMinusSrcAlpha
+            Stencil
+            {
+                Ref[_StencilNo]
+                Comp[_StencilComp]
+                Pass[_StencilOpPass]
+                Fail[_StencilOpFail]
+
+            }
+            CGPROGRAM
+            #define TESSELLATION_ON
+            #pragma target 5.0
+            #pragma vertex tess_VertexInput
+            #pragma hull hs_VertexInput
+            #pragma domain ds_surf
+            #pragma fragment frag
+	    #ifdef TESSELLATION_ON
+            #include "../../Legacy/Shaders/UCTS_Tess.cginc"
+            #endif
+            #include "UnityCG.cginc"
+            //#pragma fragmentoption ARB_precision_hint_fastest
+            //#pragma multi_compile_shadowcaster
+            //#pragma multi_compile_fog
+            #pragma only_renderers d3d9 d3d11 glcore gles gles3 playstation xboxone xboxseries vulkan metal switch
+
+	    //V.2.0.4
+            #pragma multi_compile _IS_OUTLINE_CLIPPING_NO
+            #pragma multi_compile _OUTLINE_NML _OUTLINE_POS
+            // Unity Toon Shader 0.5.0
+            #pragma multi_compile _ _DISABLE_OUTLINE
+            //The outline process goes to UTS_Outline.cginc.
+            #include "../../Legacy/Shaders/UCTS_Outline_tess.cginc"
             ENDCG
         }
         Pass {

--- a/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToonTessellation.shader
+++ b/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToonTessellation.shader
@@ -1193,53 +1193,6 @@ Shader "Toon(Tessellation)" {
             "RenderType"="Opaque"
             "RenderPipeline" = "UniversalPipeline"
         }
-        Pass {
-            Name "Outline"
-            Tags {
-                "LightMode" = "SRPDefaultUnlit"
-            }
-            Cull [_SRPDefaultUnlitColMode]
-            ColorMask [_SPRDefaultUnlitColorMask]
-            Blend SrcAlpha OneMinusSrcAlpha
-            Stencil
-            {
-                Ref[_StencilNo]
-                Comp[_StencilComp]
-                Pass[_StencilOpPass]
-                Fail[_StencilOpFail]
-
-            }
-
-            HLSLPROGRAM
-            #pragma target 2.0
-	    
-            #pragma vertex vert
-            #pragma fragment frag
-
-
-            //V.2.0.4
-            #pragma multi_compile _IS_OUTLINE_CLIPPING_NO _IS_OUTLINE_CLIPPING_YES
-            #pragma multi_compile _OUTLINE_NML _OUTLINE_POS
-            // Outline is implemented in UniversalToonOutline.hlsl.
-            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
-
-            //--------------------------------------
-            // GPU Instancing
-            #pragma multi_compile_instancing
-        #if UNITY_VERSION >= 202230 // Requires Universal RP 14.0.7
-            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
-        #else
-            #pragma multi_compile _ DOTS_INSTANCING_ON
-        #endif
-
-#ifdef UNIVERSAL_PIPELINE_CORE_INCLUDED
-            #include "../../UniversalRP/Shaders/UniversalToonInput.hlsl"
-            #include "../../UniversalRP/Shaders/UniversalToonHead.hlsl"
-            #include "../../UniversalRP/Shaders/UniversalToonOutline.hlsl"
-#endif
-            ENDHLSL
-        }
 
 //ToonCoreStart
         Pass {
@@ -1353,6 +1306,53 @@ Shader "Toon(Tessellation)" {
 #endif
             ENDHLSL
             
+        }
+
+        Pass {
+            Name "Outline"
+            Tags {
+                "LightMode" = "SRPDefaultUnlit"
+            }
+            Cull [_SRPDefaultUnlitColMode]
+            ColorMask [_SPRDefaultUnlitColorMask]
+            Blend SrcAlpha OneMinusSrcAlpha
+            Stencil
+            {
+                Ref[_StencilNo]
+                Comp[_StencilComp]
+                Pass[_StencilOpPass]
+                Fail[_StencilOpFail]
+
+            }
+
+            HLSLPROGRAM
+            #pragma target 2.0
+            #pragma vertex vert
+            #pragma fragment frag
+
+
+            //V.2.0.4
+            #pragma multi_compile _IS_OUTLINE_CLIPPING_NO _IS_OUTLINE_CLIPPING_YES
+            #pragma multi_compile _OUTLINE_NML _OUTLINE_POS
+            // Outline is implemented in UniversalToonOutline.hlsl.
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+        #if UNITY_VERSION >= 202230 // Requires Universal RP 14.0.7
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+        #else
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+        #endif
+
+#ifdef UNIVERSAL_PIPELINE_CORE_INCLUDED
+            #include "../../UniversalRP/Shaders/UniversalToonInput.hlsl"
+            #include "../../UniversalRP/Shaders/UniversalToonHead.hlsl"
+            #include "../../UniversalRP/Shaders/UniversalToonOutline.hlsl"
+#endif
+            ENDHLSL
         }
 
         Pass


### PR DESCRIPTION
# Summary
- The following issues have been fixed.
- https://github.com/Unity-Technologies/com.unity.toonshader/issues/238
- https://github.com/Unity-Technologies/com.unity.toonshader/issues/358

# Environment
- OS: Windows11
- Unity Versions: 
    - [x] 2023.2.17f1 URP Forward
    - [x] 2022.3.5f1   URP Forward
    - [x] 2022.3.5f1   URP Forward+
    - [x] 2022.3.5f1   BRP
    - [x] 2021.3.37f1 URP Forward
    - [x] 2020.3.48f1 URP Forward

# Details
- The bug seems to be caused by the fact that OutlinePass is written before ForwardLitPass.
- I was able to fix this by putting the description of OutlinePass after ForwardLitPass.
- I don't think this fix will cause the Outline to be drawn incorrectly.
- The bug did not occur in HDRP