### PR TITLE
calling InitializeBacedGIData() is necessary  for  newer than 6000.0.12.

### DIFF
--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
@@ -75,7 +75,7 @@
     #endif  //    #if (VERSION_LOWER(12, 0))  
 #  endif
                 InitializeInputData(input, surfaceData.normalTS, inputData);
-#  if UNITY_VERSION >= 60000000
+#  if UNITY_VERSION >= 60000012
                 InitializeBakedGIData(input, inputData);
 #  endif
                 BRDFData brdfData;

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyDoubleShadeWithFeather.hlsl
@@ -75,7 +75,9 @@
     #endif  //    #if (VERSION_LOWER(12, 0))  
 #  endif
                 InitializeInputData(input, surfaceData.normalTS, inputData);
-
+#  if UNITY_VERSION >= 60000000
+                InitializeBakedGIData(input, inputData);
+#  endif
                 BRDFData brdfData;
                 InitializeBRDFData(surfaceData.albedo,
                     surfaceData.metallic,

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
@@ -71,7 +71,7 @@
 #    endif //(VERSION_LOWER(12, 0))
 #  endif
                 InitializeInputData(input, surfaceData.normalTS, inputData);
-#  if UNITY_VERSION >= 60000000
+#  if UNITY_VERSION >= 60000012
                 InitializeBakedGIData(input, inputData);
 #  endif
                 BRDFData brdfData;

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonBodyShadingGradeMap.hlsl
@@ -71,7 +71,9 @@
 #    endif //(VERSION_LOWER(12, 0))
 #  endif
                 InitializeInputData(input, surfaceData.normalTS, inputData);
-
+#  if UNITY_VERSION >= 60000000
+                InitializeBakedGIData(input, inputData);
+#  endif
                 BRDFData brdfData;
                 InitializeBRDFData(surfaceData.albedo,
                     surfaceData.metallic,


### PR DESCRIPTION
This PR is a fix for #395.
This issue started from Unity 60000.0.12f1, the initialization process in URP lit shaders is now separated, as shown here:
https://github.com/Unity-Technologies/Graphics/blame/master/Packages/com.unity.render-pipelines.universal/Shaders/BakedLitForwardPass.hlsl#L171

Because of this change, we'll need to add code to initialize GI.