### PR TITLE
chore: use Unity 2022.3 for the doc build job

### DIFF
--- a/.yamato/build-documentation.yml
+++ b/.yamato/build-documentation.yml
@@ -8,7 +8,7 @@ build_documentation_for_toonshader:
   commands:
   - brick_source: git@github.cds.internal.unity3d.com:wind-xu/virtual_production_doc_generation.git@v0.3.6
     variables:
-      EDITOR_VERSION: 6000.0
+      EDITOR_VERSION: 2022.3
       PACKAGE_NAME: com.unity.toonshader
       PACKAGE_PATH: ./com.unity.toonshader
       WARNINGS_AS_ERRORS: false


### PR DESCRIPTION
(cherry picked from commit 8bcc9603859eb965aa88d1ecbac0c006b2972a84)

[skip ci]