### PR TITLE
feat: make toon URP work show basic colors/texture and outline in 2D light environment

### DIFF
--- a/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToon.shader
+++ b/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToon.shader
@@ -1303,6 +1303,43 @@ Shader "Toon" {
 
         Pass
         {
+            Name "Universal2D"
+            Tags
+            {
+                "LightMode" = "Universal2D"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            Blend[_SrcBlend][_DstBlend]
+            ZWrite[_ZWrite]
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma target 2.0
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex vert
+            #pragma fragment frag
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _ALPHAPREMULTIPLY_ON
+
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include "../../UniversalRP/Shaders/UniversalBasic2D.hlsl"
+            ENDHLSL
+        }
+
+
+        Pass
+        {
             Name "ShadowCaster"
             Tags{"LightMode" = "ShadowCaster"}
 

--- a/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToonTessellation.shader
+++ b/com.unity.toonshader/Runtime/Integrated/Shaders/UnityToonTessellation.shader
@@ -1357,6 +1357,42 @@ Shader "Toon(Tessellation)" {
 
         Pass
         {
+            Name "Universal2D"
+            Tags
+            {
+                "LightMode" = "Universal2D"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            Blend[_SrcBlend][_DstBlend]
+            ZWrite[_ZWrite]
+            Cull[_Cull]
+
+            HLSLPROGRAM
+            #pragma target 2.0
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex vert
+            #pragma fragment frag
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _ALPHAPREMULTIPLY_ON
+
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include "../../UniversalRP/Shaders/UniversalBasic2D.hlsl"
+            ENDHLSL
+        }
+
+        Pass
+        {
             Name "ShadowCaster"
             Tags{"LightMode" = "ShadowCaster"}
 

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalBasic2D.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalBasic2D.hlsl
@@ -38,8 +38,7 @@ half4 frag(Varyings input) : SV_Target
 {
     UNITY_SETUP_INSTANCE_ID(input);
     half2 uv = input.uv;
-    half4 texColor = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, TRANSFORM_TEX(uv, _MainTex));
-//    half4 texColor = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, uv);
+    half4 texColor = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, uv);
     half3 color = texColor.rgb * _BaseColor.rgb;
     half alpha = texColor.a * _BaseColor.a;
     AlphaDiscard(alpha, _Cutoff);

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalBasic2D.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalBasic2D.hlsl
@@ -1,0 +1,53 @@
+#ifndef UNIVERSAL_UTS_FALLBACK_2D_INCLUDED
+#define UNIVERSAL_UTS_FALLBACK_2D_INCLUDED
+
+float4 _MainTex_ST;
+TEXTURE2D(_MainTex); SAMPLER(sampler_MainTex);
+
+struct Attributes
+{
+    float4 positionOS       : POSITION;
+    float2 uv               : TEXCOORD0;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
+};
+
+struct Varyings
+{
+    float2 uv        : TEXCOORD0;
+    float4 vertex : SV_POSITION;
+    UNITY_VERTEX_INPUT_INSTANCE_ID
+};
+
+
+
+Varyings vert(Attributes input)
+{
+    Varyings output = (Varyings)0;
+
+    UNITY_SETUP_INSTANCE_ID(input);
+    UNITY_TRANSFER_INSTANCE_ID(input, output);
+
+    VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);
+    output.vertex = vertexInput.positionCS;
+    output.uv = TRANSFORM_TEX(input.uv, _MainTex);
+
+    return output;
+}
+
+half4 frag(Varyings input) : SV_Target
+{
+    UNITY_SETUP_INSTANCE_ID(input);
+    half2 uv = input.uv;
+    half4 texColor = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, TRANSFORM_TEX(uv, _MainTex));
+//    half4 texColor = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, uv);
+    half3 color = texColor.rgb * _BaseColor.rgb;
+    half alpha = texColor.a * _BaseColor.a;
+    AlphaDiscard(alpha, _Cutoff);
+
+#ifdef _ALPHAPREMULTIPLY_ON
+    color *= alpha;
+#endif
+    return half4(color, alpha);
+}
+
+#endif

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalBasic2D.hlsl.meta
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalBasic2D.hlsl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8990e4bdc37994bba8c402d66e2439d2
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR is related to [UJN-266](https://jira.unity3d.com/browse/UJN-266).

In a 2D lighting environment, Unity Toon Shader (UTS) objects appear black when using URP shaders because they lack a Universal2D pass. This PR adds that pass, ensuring UTS objects are visible in 2D lighting scenes. Note that, similar to the Universal RP Lit shader, these objects will not respond to 2D lights; they only display their own colors.

By adopting this approach, we maintain consistency with the Universal RP Lit behavior while making UTS materials visible in 2D scenes.

The attached image shows which passes are invoked in a 2D lighting scene, describing that this PR works as intended.
![image (2)](https://github.com/user-attachments/assets/0117ed65-7bbf-4b29-b263-1aa64dc5b420)
![image (1)](https://github.com/user-attachments/assets/6c03b948-5c90-446e-86f6-ac965905f43d)
![image](https://github.com/user-attachments/assets/4707bd59-0e20-4095-bacb-f31cac4c8734)
