### PR TITLE
fix: errors when unlit mode is selected in the SceneView

### DIFF
--- a/com.unity.toonshader/Runtime/HDRP/Shaders/ShaderPassForwardUTS.hlsl
+++ b/com.unity.toonshader/Runtime/HDRP/Shaders/ShaderPassForwardUTS.hlsl
@@ -227,6 +227,24 @@ void Frag(PackedVaryingsToPS packedInput,
     context.positionWS       = posInput.positionWS;
 #endif
 
+#if defined(DEBUG_DISPLAY) && !defined(UTS_DEBUG_SHADOWMAP) && !defined(UTS_DEBUG_SELFSHADOW)
+    // In Unity's SceneView, the Unlit mode is internally handled using the DEBUG_DISPLAY define.
+    // In official HDRP shaders, this macro is often combined with other debug macros to display various kinds of debug information,
+    // However, UTS does not implement these advanced debug visualizations. Supporting all of them is outside the scope of UTS.
+    // Therefore, if no other debug macros (e.g., UTS_DEBUG_SHADOWMAP, UTS_DEBUG_SELFSHADOW) are defined, we treat this as SceneView's Unlit mode and simply output the main texture color.
+
+    float4 _MainTex_var = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, TRANSFORM_TEX(input.texCoord0, _MainTex));
+    outColor = float4(_MainTex_var.rgb, 1.0f);
+    #ifdef _DEPTHOFFSET_ON
+    outputDepth = posInput.deviceDepth;
+    #endif
+    #ifdef UNITY_VIRTUAL_TEXTURING
+
+    outVTFeedback = builtinData.vtPackedFeedback;
+    #endif
+    return;
+#endif
+    
     // With XR single-pass and camera-relative: offset position to do lighting computations from the combined center view (original camera matrix).
     // This is required because there is only one list of lights generated on the CPU. Shadows are also generated once and shared between the instanced views.
     ApplyCameraRelativeXR(posInput.positionWS);

--- a/com.unity.toonshader/Runtime/HDRP/Shaders/ShaderPassForwardUTS.hlsl
+++ b/com.unity.toonshader/Runtime/HDRP/Shaders/ShaderPassForwardUTS.hlsl
@@ -230,7 +230,7 @@ void Frag(PackedVaryingsToPS packedInput,
 #if defined(DEBUG_DISPLAY) && !defined(UTS_DEBUG_SHADOWMAP) && !defined(UTS_DEBUG_SELFSHADOW)
     // In Unity's SceneView, the Unlit mode is internally handled using the DEBUG_DISPLAY define.
     // In official HDRP shaders, this macro is often combined with other debug macros to display various kinds of debug information,
-    // However, UTS does not implement these advanced debug visualizations. Supporting all of them is outside the scope of UTS.
+    // However, UTS currently does not implement these advanced debug visualizations. 
     // Therefore, if no other debug macros (e.g., UTS_DEBUG_SHADOWMAP, UTS_DEBUG_SELFSHADOW) are defined, we treat this as SceneView's Unlit mode and simply output the main texture color.
 
     float4 _MainTex_var = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, TRANSFORM_TEX(input.texCoord0, _MainTex));

--- a/com.unity.toonshader/Runtime/HDRP/Shaders/UtsHdrpProperties.hlsl
+++ b/com.unity.toonshader/Runtime/HDRP/Shaders/UtsHdrpProperties.hlsl
@@ -3,6 +3,8 @@
 // On PS4, texture/sampler declarations need to be outside of CBuffers
 // Otherwise those parameters are not bound correctly at runtime.
 // ===========================================================================
+#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/DebugMipmapStreamingMacros.hlsl"
+
 #ifndef fixed
 #define fixed  half
 #endif
@@ -282,6 +284,7 @@ PROP_DECL(float, _LinkDetailsWithBase);
 
 #endif // LAYERED_LIT_SHADER
 
+UNITY_TEXTURE_STREAMING_DEBUG_VARS
 
 
 // Tessellation specific

--- a/com.unity.toonshader/Runtime/HDRP/Shaders/UtsHdrpProperties.hlsl
+++ b/com.unity.toonshader/Runtime/HDRP/Shaders/UtsHdrpProperties.hlsl
@@ -3,7 +3,9 @@
 // On PS4, texture/sampler declarations need to be outside of CBuffers
 // Otherwise those parameters are not bound correctly at runtime.
 // ===========================================================================
+#if DEBUG_DISPLAY
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/DebugMipmapStreamingMacros.hlsl"
+#endif
 
 #ifndef fixed
 #define fixed  half
@@ -284,8 +286,9 @@ PROP_DECL(float, _LinkDetailsWithBase);
 
 #endif // LAYERED_LIT_SHADER
 
+#if DEBUG_DISPLAY
 UNITY_TEXTURE_STREAMING_DEBUG_VARS
-
+#endif
 
 // Tessellation specific
 


### PR DESCRIPTION
### This PR addresses errors occurring when the Scene View is set to "Unlit" mode.

An error was previously reported in PR #429 (see [this comment](https://github.com/Unity-Technologies/com.unity.toonshader/pull/429#issuecomment-2954542345)). This PR resolves that issue and properly handles unlit rendering in the Scene View.

### Specifically, this PR includes the following fixes:

- Avoids shader compilation errors by adding missing variable declarations to the CBUFFER.
- Ensures correct rendering results when the Scene View is set to "Unlit" mode.

![image](https://github.com/user-attachments/assets/130a3458-3e9e-4af4-845c-7fcb548e28a2)

You might wonder why the shader macro **DEBUG_DISPLAY** is related to unlit rendering. Historically, Unity HDRP provided the "Unlit" mode by setting Material Debug Mode → Unlit via the Rendering Debugger window. However, in recent HDRP versions, this feature has been moved directly into the Scene View mode button. In Unity 2022.3, there was no such direct Scene View mode for HDRP.

### For reference, the following table shows when Unity HDRP defines the shader macro DEBUG_DISPLAY depending on the Scene View draw mode:

| Scene View Draw Mode | `DEBUG_DISPLAY` Defined? |
|----------------------|---------------------------|
| Shaded               | ❌ No                     |
| Unlit                | ✅ Yes                    |
| Wireframe            | ❌ No                     |
| Shaded Wireframe     | ❌ No                     |