### PR TITLE
fix: dark areas instead of outlines in WebGL and OpenGL

### DIFF
--- a/com.unity.toonshader/Runtime/HDRP/Shaders/HDRPToonOutlineVertMain.hlsl
+++ b/com.unity.toonshader/Runtime/HDRP/Shaders/HDRPToonOutlineVertMain.hlsl
@@ -21,7 +21,7 @@
         //v.2.0.7.5
         float4 _ClipCameraPos = mul(UNITY_MATRIX_VP, float4(_WorldSpaceCameraPos.xyz, 1));
         //v.2.0.7
-#if defined(UNITY_REVERSED_Z)
+#if defined(UNITY_REVERSED_Z) ||  (UNITY_VERSION >= 202230)
     //v.2.0.4.2 (DX)
         _Offset_Z = _Offset_Z * -0.01;
 #else

--- a/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_Outline.cginc
+++ b/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_Outline.cginc
@@ -46,7 +46,7 @@
                 //v.2.0.7.5
                 float4 _ClipCameraPos = mul(UNITY_MATRIX_VP, float4(_WorldSpaceCameraPos.xyz, 1));
                 //v.2.0.7
-                #if defined(UNITY_REVERSED_Z)
+                #if defined(UNITY_REVERSED_Z) ||  (UNITY_VERSION >= 202230)
                     //v.2.0.4.2 (DX)
                     _Offset_Z = _Offset_Z * -0.01;
                 #else

--- a/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_Outline_Tess.cginc
+++ b/com.unity.toonshader/Runtime/Legacy/Shaders/UCTS_Outline_Tess.cginc
@@ -56,7 +56,7 @@ struct VertexOutput {
                 //v.2.0.7.5
                 float4 _ClipCameraPos = mul(UNITY_MATRIX_VP, float4(_WorldSpaceCameraPos.xyz, 1));
                 //v.2.0.7
-                #if defined(UNITY_REVERSED_Z)
+                #if defined(UNITY_REVERSED_Z) ||  (UNITY_VERSION >= 202230)
                     //v.2.0.4.2 (DX)
                     _Offset_Z = _Offset_Z * -0.01;
                 #else

--- a/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonOutline.hlsl
+++ b/com.unity.toonshader/Runtime/UniversalRP/Shaders/UniversalToonOutline.hlsl
@@ -46,7 +46,7 @@
                 //v.2.0.7.5
                 float4 _ClipCameraPos = mul(UNITY_MATRIX_VP, float4(_WorldSpaceCameraPos.xyz, 1));
                 //v.2.0.7
-                #if defined(UNITY_REVERSED_Z)
+                #if defined(UNITY_REVERSED_Z) ||  (UNITY_VERSION >= 202230)
                     //v.2.0.4.2 (DX)
                     _Offset_Z = _Offset_Z * -0.01;
                 #else


### PR DESCRIPTION
This PR fixes #410.
<img width="466" height="748" alt="image" src="https://github.com/user-attachments/assets/a4ea69f8-c050-4d3e-9fd2-59813aae2766" />


You might find the following #if condition strange:

#if defined(UNITY_REVERSED_Z) || (UNITY_VERSION >= 202230)

Since it's difficult to pinpoint exactly which Unity version introduced this issue, I applied the fix to all currently supported Unity versions.

I've created a branch that includes some projects ready for building WebGL and OpenGL players:
[dev/wbGlOutlineIssueWithProject ](https://github.com/Unity-Technologies/com.unity.toonshader/tree/dev/wbGlOutlineIssueWithProject)

The test projects are:
- ToonShader_ProjectLegacy
- ToonShader_ProjectURP

**Note:**
HDRP is not compatible with OpenGL and WebGL.
The HDRP shader was also fixed for consistency.