### PR TITLE
remove: unused fog-related code in URP shaders

### DIFF
--- a/com.unity.toonshader/Runtime/Shaders/URP/UniversalToonBody.hlsl
+++ b/com.unity.toonshader/Runtime/Shaders/URP/UniversalToonBody.hlsl
@@ -165,11 +165,6 @@ struct VertexOutput {
     float mirrorFlag : TEXCOORD6;
 
     DECLARE_LIGHTMAP_OR_SH(lightmapUV, vertexSH, 7);
-#if defined(_ADDITIONAL_LIGHTS_VERTEX) || (VERSION_LOWER(12, 0))
-    half4 fogFactorAndVertexLight : TEXCOORD8; // x: fogFactor, yzw: vertex light
-#else
-    half fogFactor : TEXCOORD8; // x: fogFactor, yzw: vertex light
-#endif
 
 #  ifdef REQUIRES_VERTEX_SHADOW_COORD_INTERPOLATOR
     float4 shadowCoord : TEXCOORD9;
@@ -314,13 +309,6 @@ VertexOutput vert(VertexInput v) {
     float4 probeOcclusionUnused;
     OUTPUT_SH4(positionWS, o.normalDir.xyz, GetWorldSpaceNormalizeViewDir(positionWS), o.vertexSH,
         probeOcclusionUnused);
-
-#if defined(_ADDITIONAL_LIGHTS_VERTEX) ||  (VERSION_LOWER(12, 0))
-    o.fogFactorAndVertexLight = half4(fogFactor, vertexLight);
-#else
-    o.fogFactor = fogFactor;
-#endif
-
     o.positionCS = positionCS;
 
 #if defined(REQUIRES_VERTEX_SHADOW_COORD_INTERPOLATOR)

--- a/com.unity.toonshader/Runtime/Shaders/URP/UniversalToonBodyDoubleShadeWithFeather.hlsl
+++ b/com.unity.toonshader/Runtime/Shaders/URP/UniversalToonBodyDoubleShadeWithFeather.hlsl
@@ -526,6 +526,8 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
 
 #endif
 
+    finalRGBA.rgb = MixFog(finalRGBA.rgb, inputData.fogCoord);
+
 #ifdef _WRITE_RENDERING_LAYERS
     uint renderingLayers = GetMeshRenderingLayer();
     outRenderingLayers = float4(EncodeMeshRenderingLayer(renderingLayers), 0, 0, 0);

--- a/com.unity.toonshader/Runtime/Shaders/URP/UniversalToonBodyDoubleShadeWithFeather.hlsl
+++ b/com.unity.toonshader/Runtime/Shaders/URP/UniversalToonBodyDoubleShadeWithFeather.hlsl
@@ -526,8 +526,6 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
 
 #endif
 
-    finalRGBA.rgb = MixFog(finalRGBA.rgb, inputData.fogCoord);
-
 #ifdef _WRITE_RENDERING_LAYERS
     uint renderingLayers = GetMeshRenderingLayer();
     outRenderingLayers = float4(EncodeMeshRenderingLayer(renderingLayers), 0, 0, 0);

--- a/com.unity.toonshader/Runtime/Shaders/URP/UniversalToonBodyDoubleShadeWithFeather.hlsl
+++ b/com.unity.toonshader/Runtime/Shaders/URP/UniversalToonBodyDoubleShadeWithFeather.hlsl
@@ -82,12 +82,6 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
 #endif
     input.uv = i.uv0;
     input.positionCS = i.pos;
-#if defined(_ADDITIONAL_LIGHTS_VERTEX)
-
-    input.fogFactorAndVertexLight = i.fogFactorAndVertexLight;
-#else
-    input.fogFactor = i.fogFactor;
-#endif
 
 #ifdef REQUIRES_VERTEX_SHADOW_COORD_INTERPOLATOR
     input.shadowCoord = i.shadowCoord;

--- a/com.unity.toonshader/Runtime/Shaders/URP/UniversalToonBodyShadingGradeMap.hlsl
+++ b/com.unity.toonshader/Runtime/Shaders/URP/UniversalToonBodyShadingGradeMap.hlsl
@@ -94,12 +94,6 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
 #endif
     input.uv = i.uv0;
     input.positionCS = i.pos;
-#if defined(_ADDITIONAL_LIGHTS_VERTEX)
-
-    input.fogFactorAndVertexLight = i.fogFactorAndVertexLight;
-#else
-    input.fogFactor = i.fogFactor;
-#endif
 
 #ifdef REQUIRES_VERTEX_SHADOW_COORD_INTERPOLATOR
     input.shadowCoord = i.shadowCoord;

--- a/com.unity.toonshader/Runtime/Shaders/URP/UniversalToonBodyShadingGradeMap.hlsl
+++ b/com.unity.toonshader/Runtime/Shaders/URP/UniversalToonBodyShadingGradeMap.hlsl
@@ -556,9 +556,6 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
 
 #endif
 
-    finalRGBA.rgb = MixFog(finalRGBA.rgb, inputData.fogCoord);
-
-    
 #ifdef _WRITE_RENDERING_LAYERS
     uint renderingLayers = GetMeshRenderingLayer();
     outRenderingLayers = float4(EncodeMeshRenderingLayer(renderingLayers), 0, 0, 0);

--- a/com.unity.toonshader/Runtime/Shaders/URP/UniversalToonBodyShadingGradeMap.hlsl
+++ b/com.unity.toonshader/Runtime/Shaders/URP/UniversalToonBodyShadingGradeMap.hlsl
@@ -556,6 +556,9 @@ void frag(VertexOutput i, out float4 finalRGBA : SV_Target0
 
 #endif
 
+    finalRGBA.rgb = MixFog(finalRGBA.rgb, inputData.fogCoord);
+
+    
 #ifdef _WRITE_RENDERING_LAYERS
     uint renderingLayers = GetMeshRenderingLayer();
     outRenderingLayers = float4(EncodeMeshRenderingLayer(renderingLayers), 0, 0, 0);

--- a/com.unity.toonshader/Runtime/Shaders/URP/UniversalToonHead.hlsl
+++ b/com.unity.toonshader/Runtime/Shaders/URP/UniversalToonHead.hlsl
@@ -79,37 +79,6 @@ inline half3 LinearToGammaSpace(half3 linRGB) {
     //return half3(LinearToGammaSpaceExact(linRGB.r), LinearToGammaSpaceExact(linRGB.g), LinearToGammaSpaceExact(linRGB.b));
 }
 
-
-#if defined(FOG_LINEAR) || defined(FOG_EXP) || defined(FOG_EXP2)
-#define UNITY_FOG_COORDS(idx) UNITY_FOG_COORDS_PACKED(idx, float1)
-
-#if (SHADER_TARGET < 30) || defined(SHADER_API_MOBILE)
-// mobile or SM2.0: calculate fog factor per-vertex
-#define UNITY_TRANSFER_FOG(o,outpos) UNITY_CALC_FOG_FACTOR((outpos).z); o.fogCoord.x = unityFogFactor
-#else
-// SM3.0 and PC/console: calculate fog distance per-vertex, and fog factor per-pixel
-#define UNITY_TRANSFER_FOG(o,outpos) o.fogCoord.x = (outpos).z
-#endif
-#else
-#define UNITY_FOG_COORDS(idx)
-#define UNITY_TRANSFER_FOG(o,outpos)
-#endif
-
-#define UNITY_FOG_LERP_COLOR(col,fogCol,fogFac) col.rgb = lerp((fogCol).rgb, (col).rgb, saturate(fogFac))
-
-
-#if defined(FOG_LINEAR) || defined(FOG_EXP) || defined(FOG_EXP2)
-#if (SHADER_TARGET < 30) || defined(SHADER_API_MOBILE)
-// mobile or SM2.0: fog factor was already calculated per-vertex, so just lerp the color
-#define UNITY_APPLY_FOG_COLOR(coord,col,fogCol) UNITY_FOG_LERP_COLOR(col,fogCol,(coord).x)
-#else
-// SM3.0 and PC/console: calculate fog factor and lerp fog color
-#define UNITY_APPLY_FOG_COLOR(coord,col,fogCol) UNITY_CALC_FOG_FACTOR((coord).x); UNITY_FOG_LERP_COLOR(col,fogCol,unityFogFactor)
-#endif
-#else
-#define UNITY_APPLY_FOG_COLOR(coord,col,fogCol)
-#endif
-
 #ifdef UNITY_PASS_FORWARDADD
 #define UNITY_APPLY_FOG(coord,col) UNITY_APPLY_FOG_COLOR(coord,col,fixed4(0,0,0,0))
 #else


### PR DESCRIPTION
We had code that is duplicate of the fog code in InitializeInputData(), and we are already calling this function