### PR TITLE
test: set XR mode in decal scenes due to "Metal: memoryless texture requires 2D texture"

### DIFF
--- a/com.unity.toon-graphics-test/Runtime/UTSGraphicsTests.cs
+++ b/com.unity.toon-graphics-test/Runtime/UTSGraphicsTests.cs
@@ -5,6 +5,7 @@ using UnityEngine.TestTools;
 using UnityEngine.TestTools.Graphics;
 using UnityEngine.SceneManagement;
 using System.IO;
+using Unity.XR.MockHMD;
 using UnityEditor;
 
 
@@ -38,6 +39,17 @@ public class UTSGraphicsTestsXR {
         if (sceneFileName.EndsWith("2D")) {
             Assert.Ignore();
         }
+
+#if UTS_TEST_USE_URP && UNITY_STANDALONE_OSX
+
+        //[Note-sin: 2026-05-01] Hack to set mode in decal scenes due to "Metal: memoryless texture requires 2D texture"
+        MockHMDBuildSettings.RenderMode mode = MockHMDBuildSettings.RenderMode.SinglePassInstanced;
+        if (sceneFileName.Contains("Decal")) {
+            mode = MockHMDBuildSettings.RenderMode.MultiPass;
+        } 
+        MockHMD.SetRenderMode(mode);
+            
+#endif //UTS_TEST_USE_HDRP && UNITY_STANDALONE_OSX 
         
 
         //Enable XR

--- a/com.unity.toon-graphics-test/Runtime/UTSGraphicsTests.cs
+++ b/com.unity.toon-graphics-test/Runtime/UTSGraphicsTests.cs
@@ -49,7 +49,7 @@ public class UTSGraphicsTestsXR {
         } 
         MockHMD.SetRenderMode(mode);
             
-#endif //UTS_TEST_USE_HDRP && UNITY_STANDALONE_OSX 
+#endif //UTS_TEST_USE_URP && UNITY_STANDALONE_OSX 
         
 
         //Enable XR

--- a/com.unity.toon-graphics-test/Runtime/Unity.ToonShader.GraphicsTest.asmdef
+++ b/com.unity.toon-graphics-test/Runtime/Unity.ToonShader.GraphicsTest.asmdef
@@ -5,7 +5,8 @@
         "GUID:c081bc530f560634bb5c21d4b323a7f1",
         "GUID:27619889b8ba8c24980f49ee34dbb44a",
         "GUID:e40ba710768534012815d3193fa296cb",
-        "GUID:e18141520846dcc44b725b2f74e91229"
+        "GUID:e18141520846dcc44b725b2f74e91229",
+        "GUID:344c59e53e2aa435db7f183483734523"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
(cherry picked from commit 403ebafaf7a10efd4d14f8e492edc10c49a41c2c)