### PR TITLE
Fix: restrict Metal foveated rendering to VisionOS

### DIFF
--- a/com.unity.toonshader/Runtime/Shaders/UnityToon.shader
+++ b/com.unity.toonshader/Runtime/Shaders/UnityToon.shader
@@ -1102,7 +1102,7 @@ Shader "Toon/Toon" {
 
             #if (!defined(UNITY_COMPILER_DXC) && (defined(UNITY_PLATFORM_OSX) || defined(UNITY_PLATFORM_IOS))) || defined(SHADER_API_PS5)
 
-                #if defined(SHADER_API_PS5) || defined(SHADER_API_METAL)
+                #if defined(SHADER_API_PS5) || (defined(SHADER_API_METAL) && defined(UNITY_VISIONOS))
 
                     #define SUPPORTS_FOVEATED_RENDERING_NON_UNIFORM_RASTER 1
 

--- a/com.unity.toonshader/Runtime/Shaders/UnityToonTessellation.shader
+++ b/com.unity.toonshader/Runtime/Shaders/UnityToonTessellation.shader
@@ -1241,7 +1241,7 @@ Shader "Toon/Toon (Tessellation)" {
 
             #if (!defined(UNITY_COMPILER_DXC) && (defined(UNITY_PLATFORM_OSX) || defined(UNITY_PLATFORM_IOS))) || defined(SHADER_API_PS5)
 
-                #if defined(SHADER_API_PS5) || defined(SHADER_API_METAL)
+                #if defined(SHADER_API_PS5) || (defined(SHADER_API_METAL) && defined(UNITY_VISIONOS))
 
                     #define SUPPORTS_FOVEATED_RENDERING_NON_UNIFORM_RASTER 1
 


### PR DESCRIPTION
Prevents standard iOS and macOS Metal targets from incorrectly enabling **SUPPORTS_FOVEATED_RENDERING_NON_UNIFORM_RASTER**.

#### Fixed error

> Shader error in 'Toon/Toon': undeclared identifier 'RemapFoveatedRenderingLinearToNonUniform' at /Library/PackageCache/com.unity.render-pipelines.core@9d79d0cd2cf7/ShaderLibrary/FoveatedRendering.hlsl(25) (on metal)

This error causes the shader to instantly fall back to the pink internal error shader. Wrapping SHADER_API_METAL with defined(UNITY_VISIONOS) ensures the build target is actually compatible with foveated rendering before defining the macro.