### PR TITLE
Fix: restrict Metal foveated rendering to VisionOS (#867)

### DIFF
--- a/com.unity.toon-graphics-test/Runtime/Resources/UTSGraphicsSettings_Built-In_XR.asset
+++ b/com.unity.toon-graphics-test/Runtime/Resources/UTSGraphicsSettings_Built-In_XR.asset
@@ -21,7 +21,7 @@ MonoBehaviour:
     PerPixelGammaThreshold: 0.003921569
     PerPixelAlphaThreshold: 0.003921569
     RMSEThreshold: 0
-    AverageCorrectnessThreshold: 0.001
+    AverageCorrectnessThreshold: 0.005
     IncorrectPixelsThreshold: 0.0000038146973
     UseHDR: 0
     UseBackBuffer: 1

--- a/com.unity.toon-graphics-test/Runtime/Resources/UTSGraphicsSettings_Built-In_XR.asset
+++ b/com.unity.toon-graphics-test/Runtime/Resources/UTSGraphicsSettings_Built-In_XR.asset
@@ -21,7 +21,7 @@ MonoBehaviour:
     PerPixelGammaThreshold: 0.003921569
     PerPixelAlphaThreshold: 0.003921569
     RMSEThreshold: 0
-    AverageCorrectnessThreshold: 0.005
+    AverageCorrectnessThreshold: 0.001
     IncorrectPixelsThreshold: 0.0000038146973
     UseHDR: 0
     UseBackBuffer: 1

--- a/com.unity.toonshader/Runtime/Shaders/Common/Parts/UnityToon.shadertemplate
+++ b/com.unity.toonshader/Runtime/Shaders/Common/Parts/UnityToon.shadertemplate
@@ -660,23 +660,8 @@ Shader "Toon/Toon" {
             #pragma multi_compile _ _FORWARD_PLUS
 #endif
 
-            #if (!defined(UNITY_COMPILER_DXC) && (defined(UNITY_PLATFORM_OSX) || defined(UNITY_PLATFORM_IOS))) || defined(SHADER_API_PS5)
+            #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
 
-                #if defined(SHADER_API_PS5) || defined(SHADER_API_METAL)
-
-                    #define SUPPORTS_FOVEATED_RENDERING_NON_UNIFORM_RASTER 1
-
-                    // On Metal Foveated Rendering is currently not supported with DXC
-                    #pragma warning (disable : 3568) // unknown pragma ignored
-
-                    #pragma never_use_dxc metal
-                    #pragma dynamic_branch _ _FOVEATED_RENDERING_NON_UNIFORM_RASTER
-
-                    #pragma warning (default : 3568) // restore unknown pragma ignored
-
-                #endif
-
-            #endif
             #pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
             #pragma multi_compile_fragment _ _LIGHT_LAYERS
 

--- a/com.unity.toonshader/Runtime/Shaders/Common/Parts/UnityToonTessellation.shadertemplate
+++ b/com.unity.toonshader/Runtime/Shaders/Common/Parts/UnityToonTessellation.shadertemplate
@@ -782,24 +782,8 @@ Shader "Toon/Toon (Tessellation)" {
             #pragma multi_compile _ _FORWARD_PLUS
 #endif
 
+            #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
 
-            #if (!defined(UNITY_COMPILER_DXC) && (defined(UNITY_PLATFORM_OSX) || defined(UNITY_PLATFORM_IOS))) || defined(SHADER_API_PS5)
-
-                #if defined(SHADER_API_PS5) || defined(SHADER_API_METAL)
-
-                    #define SUPPORTS_FOVEATED_RENDERING_NON_UNIFORM_RASTER 1
-
-                    // On Metal Foveated Rendering is currently not supported with DXC
-                    #pragma warning (disable : 3568) // unknown pragma ignored
-
-                    #pragma never_use_dxc metal
-                    #pragma dynamic_branch _ _FOVEATED_RENDERING_NON_UNIFORM_RASTER
-
-                    #pragma warning (default : 3568) // restore unknown pragma ignored
-
-                #endif
-
-            #endif
             #pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
             #pragma multi_compile_fragment _ _LIGHT_LAYERS
 

--- a/com.unity.toonshader/Runtime/Shaders/UnityToon.shader
+++ b/com.unity.toonshader/Runtime/Shaders/UnityToon.shader
@@ -1,4 +1,4 @@
-//Auto-generated on Wed Jun 24 02:54:04 UTC 2026
+//Auto-generated on Fri Aug 21 10:47:46 UTC 2026
 Shader "Toon/Toon" {
     Properties
     {
@@ -1100,23 +1100,8 @@ Shader "Toon/Toon" {
             #pragma multi_compile _ _FORWARD_PLUS
 #endif
 
-            #if (!defined(UNITY_COMPILER_DXC) && (defined(UNITY_PLATFORM_OSX) || defined(UNITY_PLATFORM_IOS))) || defined(SHADER_API_PS5)
+            #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
 
-                #if defined(SHADER_API_PS5) || (defined(SHADER_API_METAL) && defined(UNITY_VISIONOS))
-
-                    #define SUPPORTS_FOVEATED_RENDERING_NON_UNIFORM_RASTER 1
-
-                    // On Metal Foveated Rendering is currently not supported with DXC
-                    #pragma warning (disable : 3568) // unknown pragma ignored
-
-                    #pragma never_use_dxc metal
-                    #pragma dynamic_branch _ _FOVEATED_RENDERING_NON_UNIFORM_RASTER
-
-                    #pragma warning (default : 3568) // restore unknown pragma ignored
-
-                #endif
-
-            #endif
             #pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
             #pragma multi_compile_fragment _ _LIGHT_LAYERS
 

--- a/com.unity.toonshader/Runtime/Shaders/UnityToon.shader
+++ b/com.unity.toonshader/Runtime/Shaders/UnityToon.shader
@@ -1102,7 +1102,7 @@ Shader "Toon/Toon" {
 
             #if (!defined(UNITY_COMPILER_DXC) && (defined(UNITY_PLATFORM_OSX) || defined(UNITY_PLATFORM_IOS))) || defined(SHADER_API_PS5)
 
-                #if defined(SHADER_API_PS5) || defined(SHADER_API_METAL)
+                #if defined(SHADER_API_PS5) || (defined(SHADER_API_METAL) && defined(UNITY_VISIONOS))
 
                     #define SUPPORTS_FOVEATED_RENDERING_NON_UNIFORM_RASTER 1
 

--- a/com.unity.toonshader/Runtime/Shaders/UnityToonTessellation.shader
+++ b/com.unity.toonshader/Runtime/Shaders/UnityToonTessellation.shader
@@ -1,4 +1,4 @@
-//Auto-generated on Wed Jun 24 02:54:04 UTC 2026
+//Auto-generated on Fri Aug 21 10:47:46 UTC 2026
 Shader "Toon/Toon (Tessellation)" {
     Properties
     {
@@ -1238,24 +1238,8 @@ Shader "Toon/Toon (Tessellation)" {
             #pragma multi_compile _ _FORWARD_PLUS
 #endif
 
+            #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
 
-            #if (!defined(UNITY_COMPILER_DXC) && (defined(UNITY_PLATFORM_OSX) || defined(UNITY_PLATFORM_IOS))) || defined(SHADER_API_PS5)
-
-                #if defined(SHADER_API_PS5) || (defined(SHADER_API_METAL) && defined(UNITY_VISIONOS))
-
-                    #define SUPPORTS_FOVEATED_RENDERING_NON_UNIFORM_RASTER 1
-
-                    // On Metal Foveated Rendering is currently not supported with DXC
-                    #pragma warning (disable : 3568) // unknown pragma ignored
-
-                    #pragma never_use_dxc metal
-                    #pragma dynamic_branch _ _FOVEATED_RENDERING_NON_UNIFORM_RASTER
-
-                    #pragma warning (default : 3568) // restore unknown pragma ignored
-
-                #endif
-
-            #endif
             #pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
             #pragma multi_compile_fragment _ _LIGHT_LAYERS
 

--- a/com.unity.toonshader/Runtime/Shaders/UnityToonTessellation.shader
+++ b/com.unity.toonshader/Runtime/Shaders/UnityToonTessellation.shader
@@ -1241,7 +1241,7 @@ Shader "Toon/Toon (Tessellation)" {
 
             #if (!defined(UNITY_COMPILER_DXC) && (defined(UNITY_PLATFORM_OSX) || defined(UNITY_PLATFORM_IOS))) || defined(SHADER_API_PS5)
 
-                #if defined(SHADER_API_PS5) || defined(SHADER_API_METAL)
+                #if defined(SHADER_API_PS5) || (defined(SHADER_API_METAL) && defined(UNITY_VISIONOS))
 
                     #define SUPPORTS_FOVEATED_RENDERING_NON_UNIFORM_RASTER 1
 


### PR DESCRIPTION
* fix: restrict Metal foveated rendering to visionOS target platforms

* fix: restrict Metal foveated rendering to visionOS (Tessellation)